### PR TITLE
Add additional test idnr for production environment

### DIFF
--- a/erica/request_processing/requests_controller.py
+++ b/erica/request_processing/requests_controller.py
@@ -18,7 +18,7 @@ from erica.pyeric.pyeric_controller import EstPyericProcessController, EstValida
 from erica.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.request_processing.erica_input.v1.erica_input import UnlockCodeRequestData, EstData
 
-SPECIAL_TESTMERKER_IDNR = '04452397687'
+SPECIAL_TESTMERKER_IDNR = ['04452397687', '02259674819']
 
 
 class EricaRequestController(object):
@@ -49,7 +49,7 @@ class EricaRequestController(object):
         raise NotImplementedError
 
     def _is_testmerker_used(self):
-        return self.input_data.idnr == SPECIAL_TESTMERKER_IDNR
+        return self.input_data.idnr in SPECIAL_TESTMERKER_IDNR
 
     def generate_json(self, pyeric_response: PyericResponse):
         response = {}
@@ -75,7 +75,7 @@ class EstValidationRequestController(TransferTicketRequestController):
         super().__init__(input_data, include_elster_responses)
 
     def _is_testmerker_used(self):
-        return self.input_data.est_data.person_a_idnr == SPECIAL_TESTMERKER_IDNR
+        return self.input_data.est_data.person_a_idnr in SPECIAL_TESTMERKER_IDNR
 
     def process(self):
         # Translate our form data structure into the fields from

--- a/erica/request_processing/requests_controller.py
+++ b/erica/request_processing/requests_controller.py
@@ -18,7 +18,16 @@ from erica.pyeric.pyeric_controller import EstPyericProcessController, EstValida
 from erica.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.request_processing.erica_input.v1.erica_input import UnlockCodeRequestData, EstData
 
-SPECIAL_TESTMERKER_IDNR = ['04452397687', '02259674819']
+SPECIAL_TESTMERKER_IDNR = ['04452397687',
+                           '02259674819',
+                           '04452317681',
+                           '09952417688',
+                           '03352417692',
+                           '03352419681',
+                           '03352417981',
+                           '03392417683',
+                           '03352917681',
+                           '03359417681']
 
 
 class EricaRequestController(object):

--- a/tests/request_processing/test_requests_controller.py
+++ b/tests/request_processing/test_requests_controller.py
@@ -110,7 +110,7 @@ class TestEstRequestProcess(unittest.TestCase):
 
     def test_if_use_testmerker_env_false_and_special_idnr_then_create_xml_is_called_with_use_testmerker_set_true(self):
         correct_est = create_est(correct_form_data=True)
-        correct_est.est_data.person_a_idnr = SPECIAL_TESTMERKER_IDNR
+        correct_est.est_data.person_a_idnr = SPECIAL_TESTMERKER_IDNR[0]
 
         with patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.EstPyericProcessController.get_eric_response'), \
@@ -261,7 +261,7 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
             dob=date(1985, 1, 1)))
 
         self.unlock_request_with_valid_input_with_special_idnr = UnlockCodeRequestController(UnlockCodeRequestData(
-            idnr=SPECIAL_TESTMERKER_IDNR,
+            idnr=SPECIAL_TESTMERKER_IDNR[0],
             dob=date(1985, 1, 1)))
 
     def test_pyeric_controller_is_initialised_with_correct_arguments(self):
@@ -410,7 +410,7 @@ class TestUnlockCodeActivationProcess(unittest.TestCase):
 
         self.unlock_activation_with_valid_input_with_special_idnr = UnlockCodeActivationRequestController(
             UnlockCodeActivationData(
-                idnr=SPECIAL_TESTMERKER_IDNR,
+                idnr=SPECIAL_TESTMERKER_IDNR[0],
                 unlock_code='1985-T67D-K89O',
                 elster_request_id='42'))
 
@@ -543,7 +543,7 @@ class TestUnlockCodeRevocationProcess(unittest.TestCase):
 
         self.unlock_revocation_with_valid_input_and_special_idnr = UnlockCodeRevocationRequestController(
             UnlockCodeRevocationData(
-                idnr=SPECIAL_TESTMERKER_IDNR,
+                idnr=SPECIAL_TESTMERKER_IDNR[0],
                 elster_request_id='lookanotherrequestid'))
 
         self.unlock_revocation_with_unknown_idnr = UnlockCodeRevocationRequestController(UnlockCodeRevocationData(


### PR DESCRIPTION
# Short Description
We sometimes have the problem that we want to test more than once per day the flow of request, activate and cancel unlock_code on production. We only have one test_idnr that we can use for that and are limited to performing this only once per day.
Therefore, this adds one more test IdNr to be used in production

# Changes
- Use an array instead of a string
- Adapt tests

# Feedback
- Do you see any problem with this?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
