### PR TITLE
Improve controller test

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ xmltodict = "*"
 pytest = "*"
 flake8 = "*"
 invoke = "*"
+xmldiff = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba7bf97ec9e806f1fec5a92e0d39d55d27e2787e4b61441d88f403aae0d35f4b"
+            "sha256": "d0a50956a6c424afbfb491fb119cd5506eb3c2bf46ca6f405eeb3c44ee6e6fbe"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -58,19 +58,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8f59383fe578ac9107466a464d7198933e5332d85a4790f2e01cf24a4a7f635b",
-                "sha256:af92931f65e33e7450c3389c6cc6ab6b3e2f619697ea5566aacc0f16f3b21f61"
+                "sha256:a235c422239d1b468924b37faa95f5750c6abd43651fe7deb3976e10a331c991",
+                "sha256:b01d29305527fe8754a0c5847c0431ec677dca34069aaed9429ff178826ab366"
             ],
             "index": "pypi",
-            "version": "==1.21.7"
+            "version": "==1.21.17"
         },
         "botocore": {
             "hashes": [
-                "sha256:46e51f56f1c5784e4245e036503635fa71b722775657b6e1acf21ec5b906974c",
-                "sha256:7b166096f9413b41caf7cc6f4edfd5b3c3ab9d7c61eb120a649e69485c98131a"
+                "sha256:29212b4be640efc047665650fee474357e884725a3e2a9bc029bca46a6ef0853",
+                "sha256:e61b9e6d0d5e384f8135211f05fc05694571505390293d939a9688ac08d4f62a"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.13"
+            "version": "==1.24.17"
         },
         "click": {
             "hashes": [
@@ -308,16 +308,16 @@
                 "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
                 "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.8"
         },
         "uvicorn": {
             "hashes": [
-                "sha256:8adddf629b79857b48b999ae1b14d6c92c95d4d7840bd86461f09bee75f1653e",
-                "sha256:c04a9c069111489c324f427501b3840d306c6b91a77b00affc136a840a3f45f1"
+                "sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6",
+                "sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23"
             ],
             "index": "pypi",
-            "version": "==0.17.5"
+            "version": "==0.17.6"
         },
         "xmltodict": {
             "hashes": [
@@ -360,6 +360,73 @@
             ],
             "index": "pypi",
             "version": "==1.6.0"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:078306d19a33920004addeb5f4630781aaeabb6a8d01398045fcde085091a169",
+                "sha256:0c1978ff1fd81ed9dcbba4f91cf09faf1f8082c9d72eb122e92294716c605428",
+                "sha256:1010042bfcac2b2dc6098260a2ed022968dbdfaf285fc65a3acf8e4eb1ffd1bc",
+                "sha256:1d650812b52d98679ed6c6b3b55cbb8fe5a5460a0aef29aeb08dc0b44577df85",
+                "sha256:20b8a746a026017acf07da39fdb10aa80ad9877046c9182442bf80c84a1c4696",
+                "sha256:2403a6d6fb61c285969b71f4a3527873fe93fd0abe0832d858a17fe68c8fa507",
+                "sha256:24f5c5ae618395ed871b3d8ebfcbb36e3f1091fd847bf54c4de623f9107942f3",
+                "sha256:28d1af847786f68bec57961f31221125c29d6f52d9187c01cd34dc14e2b29430",
+                "sha256:31499847fc5f73ee17dbe1b8e24c6dafc4e8d5b48803d17d22988976b0171f03",
+                "sha256:31ba2cbc64516dcdd6c24418daa7abff989ddf3ba6d3ea6f6ce6f2ed6e754ec9",
+                "sha256:330bff92c26d4aee79c5bc4d9967858bdbe73fdbdbacb5daf623a03a914fe05b",
+                "sha256:5045ee1ccd45a89c4daec1160217d363fcd23811e26734688007c26f28c9e9e7",
+                "sha256:52cbf2ff155b19dc4d4100f7442f6a697938bf4493f8d3b0c51d45568d5666b5",
+                "sha256:530f278849031b0eb12f46cca0e5db01cfe5177ab13bd6878c6e739319bae654",
+                "sha256:545bd39c9481f2e3f2727c78c169425efbfb3fbba6e7db4f46a80ebb249819ca",
+                "sha256:5804e04feb4e61babf3911c2a974a5b86f66ee227cc5006230b00ac6d285b3a9",
+                "sha256:5a58d0b12f5053e270510bf12f753a76aaf3d74c453c00942ed7d2c804ca845c",
+                "sha256:5f148b0c6133fb928503cfcdfdba395010f997aa44bcf6474fcdd0c5398d9b63",
+                "sha256:5f7d7d9afc7b293147e2d506a4596641d60181a35279ef3aa5778d0d9d9123fe",
+                "sha256:60d2f60bd5a2a979df28ab309352cdcf8181bda0cca4529769a945f09aba06f9",
+                "sha256:6259b511b0f2527e6d55ad87acc1c07b3cbffc3d5e050d7e7bcfa151b8202df9",
+                "sha256:6268e27873a3d191849204d00d03f65c0e343b3bcb518a6eaae05677c95621d1",
+                "sha256:627e79894770783c129cc5e89b947e52aa26e8e0557c7e205368a809da4b7939",
+                "sha256:62f93eac69ec0f4be98d1b96f4d6b964855b8255c345c17ff12c20b93f247b68",
+                "sha256:6d6483b1229470e1d8835e52e0ff3c6973b9b97b24cd1c116dca90b57a2cc613",
+                "sha256:6f7b82934c08e28a2d537d870293236b1000d94d0b4583825ab9649aef7ddf63",
+                "sha256:6fe4ef4402df0250b75ba876c3795510d782def5c1e63890bde02d622570d39e",
+                "sha256:719544565c2937c21a6f76d520e6e52b726d132815adb3447ccffbe9f44203c4",
+                "sha256:730766072fd5dcb219dd2b95c4c49752a54f00157f322bc6d71f7d2a31fecd79",
+                "sha256:74eb65ec61e3c7c019d7169387d1b6ffcfea1b9ec5894d116a9a903636e4a0b1",
+                "sha256:7993232bd4044392c47779a3c7e8889fea6883be46281d45a81451acfd704d7e",
+                "sha256:80bbaddf2baab7e6de4bc47405e34948e694a9efe0861c61cdc23aa774fcb141",
+                "sha256:86545e351e879d0b72b620db6a3b96346921fa87b3d366d6c074e5a9a0b8dadb",
+                "sha256:891dc8f522d7059ff0024cd3ae79fd224752676447f9c678f2a5c14b84d9a939",
+                "sha256:8a31f24e2a0b6317f33aafbb2f0895c0bce772980ae60c2c640d82caac49628a",
+                "sha256:8b99ec73073b37f9ebe8caf399001848fced9c08064effdbfc4da2b5a8d07b93",
+                "sha256:986b7a96228c9b4942ec420eff37556c5777bfba6758edcb95421e4a614b57f9",
+                "sha256:a1547ff4b8a833511eeaceacbcd17b043214fcdb385148f9c1bc5556ca9623e2",
+                "sha256:a2bfc7e2a0601b475477c954bf167dee6d0f55cb167e3f3e7cefad906e7759f6",
+                "sha256:a3c5f1a719aa11866ffc530d54ad965063a8cbbecae6515acbd5f0fae8f48eaa",
+                "sha256:a9f1c3489736ff8e1c7652e9dc39f80cff820f23624f23d9eab6e122ac99b150",
+                "sha256:aa0cf4922da7a3c905d000b35065df6184c0dc1d866dd3b86fd961905bbad2ea",
+                "sha256:ad4332a532e2d5acb231a2e5d33f943750091ee435daffca3fec0a53224e7e33",
+                "sha256:b2582b238e1658c4061ebe1b4df53c435190d22457642377fd0cb30685cdfb76",
+                "sha256:b6fc2e2fb6f532cf48b5fed57567ef286addcef38c28874458a41b7837a57807",
+                "sha256:b92d40121dcbd74831b690a75533da703750f7041b4bf951befc657c37e5695a",
+                "sha256:bbab6faf6568484707acc052f4dfc3802bdb0cafe079383fbaa23f1cdae9ecd4",
+                "sha256:c0b88ed1ae66777a798dc54f627e32d3b81c8009967c63993c450ee4cbcbec15",
+                "sha256:ce13d6291a5f47c1c8dbd375baa78551053bc6b5e5c0e9bb8e39c0a8359fd52f",
+                "sha256:db3535733f59e5605a88a706824dfcb9bd06725e709ecb017e165fc1d6e7d429",
+                "sha256:dd10383f1d6b7edf247d0960a3db274c07e96cf3a3fc7c41c8448f93eac3fb1c",
+                "sha256:e01f9531ba5420838c801c21c1b0f45dbc9607cb22ea2cf132844453bec863a5",
+                "sha256:e11527dc23d5ef44d76fef11213215c34f36af1608074561fcc561d983aeb870",
+                "sha256:e1ab2fac607842ac36864e358c42feb0960ae62c34aa4caaf12ada0a1fb5d99b",
+                "sha256:e1fd7d2fe11f1cb63d3336d147c852f6d07de0d0020d704c6031b46a30b02ca8",
+                "sha256:e9f84ed9f4d50b74fbc77298ee5c870f67cb7e91dcdc1a6915cb1ff6a317476c",
+                "sha256:ec4b4e75fc68da9dc0ed73dcdb431c25c57775383fec325d23a770a64e7ebc87",
+                "sha256:f10ce66fcdeb3543df51d423ede7e238be98412232fca5daec3e54bcd16b8da0",
+                "sha256:f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23",
+                "sha256:fa56bb08b3dd8eac3a8c5b7d075c94e74f755fd9d8a04543ae8d37b1612dd170",
+                "sha256:fa9b7c450be85bfc6cd39f6df8c5b8cbd76b5d6fc1f69efec80203f9894b885f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.8.0"
         },
         "mccabe": {
             "hashes": [
@@ -424,6 +491,22 @@
             "index": "pypi",
             "version": "==7.0.1"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
+                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==60.9.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
@@ -431,6 +514,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
+        },
+        "xmldiff": {
+            "hashes": [
+                "sha256:05bea20ce1f2c9678683bcce0c3ba9981f87d92b709d190e018bcbf047eccf63",
+                "sha256:213c2f4c39ed71811a9ceeec1c8bdf2e673e5527261ea11708b3acfa6c2bdb00"
+            ],
+            "index": "pypi",
+            "version": "==2.4"
         }
     }
 }

--- a/tests/request_processing/test_grundsteuer_request_controller.py
+++ b/tests/request_processing/test_grundsteuer_request_controller.py
@@ -1,10 +1,10 @@
 import base64
 import json
-import string
 from unittest.mock import patch, MagicMock
 from xml.etree import ElementTree
 
 import pytest
+from xmldiff import main
 
 from erica.pyeric.pyeric_response import PyericResponse
 from erica.request_processing.erica_input.v2.grundsteuer_input import GrundsteuerData
@@ -55,14 +55,17 @@ class TestGenerateFullXml:
             resulting_xml = request_controller.generate_full_xml(use_testmerker=True)
             with open('tests/samples/grundsteuer_sample_xml.xml') as f:
                 expected_xml = f.read()
-                assert resulting_xml.translate(str.maketrans('', '', string.whitespace)) == expected_xml.translate(str.maketrans('', '', string.whitespace))
+                diff = main.diff_texts(bytes(bytearray(resulting_xml, "utf8")),
+                                       expected_xml.encode())
+                assert diff == []
 
 
 class TestGenerateJson:
     def test_result_includes_all_relevant_aspects(self, valid_grundsteuer_request_controller):
         valid_grundsteuer_request_controller.include_elster_responses = True
         example_pyeric_response = PyericResponse("eric response", "server response", "pdf content".encode())
-        with patch('erica.request_processing.requests_controller.get_transfer_ticket_from_xml', MagicMock(return_value='transfer ticket')):
+        with patch('erica.request_processing.requests_controller.get_transfer_ticket_from_xml',
+                   MagicMock(return_value='transfer ticket')):
             result = valid_grundsteuer_request_controller.generate_json(example_pyeric_response)
             assert result['pdf'] == base64.b64encode("pdf content".encode())
             assert result['transfer_ticket'] == 'transfer ticket'

--- a/tests/request_processing/test_grundsteuer_request_controller.py
+++ b/tests/request_processing/test_grundsteuer_request_controller.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import string
 from unittest.mock import patch, MagicMock
 from xml.etree import ElementTree
@@ -9,7 +10,6 @@ from erica.pyeric.pyeric_response import PyericResponse
 from erica.request_processing.erica_input.v2.grundsteuer_input import GrundsteuerData
 from erica.request_processing.grundsteuer_request_controller import GrundsteuerRequestController
 from tests.samples.grundsteuer_sample_data import get_grundsteuer_sample_data
-from tests.samples.grundsteuer_sample_input import grundsteuer_sample_input
 from tests.utils import missing_cert, missing_pyeric_lib
 
 
@@ -48,12 +48,14 @@ class TestGenerateFullXml:
         assert "<NutzdatenHeader" in resulting_xml
 
     def test_returns_full_expected_xml_for_given_input(self):
-        valid_input = GrundsteuerData.parse_obj(grundsteuer_sample_input)
-        request_controller = GrundsteuerRequestController(valid_input)
-        resulting_xml = request_controller.generate_full_xml(use_testmerker=True)
-        with open('tests/samples/grundsteuer_sample_xml.xml') as f:
-            expected_xml = f.read()
-            assert resulting_xml.translate(str.maketrans('', '', string.whitespace)) == expected_xml.translate(str.maketrans('', '', string.whitespace))
+        with open('tests/samples/grundsteuer_sample_input.json') as json_file:
+            payload = json.loads(json_file.read())
+            parsed_input = GrundsteuerData.parse_obj(payload)
+            request_controller = GrundsteuerRequestController(parsed_input)
+            resulting_xml = request_controller.generate_full_xml(use_testmerker=True)
+            with open('tests/samples/grundsteuer_sample_xml.xml') as f:
+                expected_xml = f.read()
+                assert resulting_xml.translate(str.maketrans('', '', string.whitespace)) == expected_xml.translate(str.maketrans('', '', string.whitespace))
 
 
 class TestGenerateJson:

--- a/tests/samples/grundsteuer_sample_input.json
+++ b/tests/samples/grundsteuer_sample_input.json
@@ -5,7 +5,7 @@
                 "anrede": "frau",
                 "titel": "Dr",
                 "name": "Granger",
-                "vorname": "Hermine",
+                "vorname": "Hermione",
                 "geburtsdatum": "1979-09-19"},
                 "adresse": {
                     "strasse": "Grimmauld Place",

--- a/tests/samples/grundsteuer_sample_input.json
+++ b/tests/samples/grundsteuer_sample_input.json
@@ -1,5 +1,4 @@
-
-grundsteuer_sample_input = {
+{
     "eigentuemer": {
         "person": [
             {"persoenlicheAngaben": {
@@ -32,12 +31,12 @@ grundsteuer_sample_input = {
                     }
                 },
                 "steuer_id": {
-                    "steuer_id": "04452317681",
+                    "steuer_id": "04452317681"
                 },
                 "anteil": {
                     "zaehler": 1,
-                    "nenner": 1,
-                },
+                    "nenner": 1
+                }
             }
         ],
         "empfangsbevollmaechtigter": {
@@ -52,11 +51,11 @@ grundsteuer_sample_input = {
                 "ort": "Hogsmeade",
                 "strasse": "Three Brooms",
                 "hausnummer": "3",
-                "hausnummerzusatz": "c",
+                "hausnummerzusatz": "c"
             },
             "telefonnummer": {
                 "telefonnummer": "123-456"
             }
-        },
+        }
     }
 }

--- a/tests/samples/grundsteuer_sample_xml.xml
+++ b/tests/samples/grundsteuer_sample_xml.xml
@@ -39,7 +39,7 @@
                         <Eigentuemer>
                             <Beteiligter>1</Beteiligter>
                             <E7404510>03</E7404510>
-                            <E7404513>Hermine</E7404513>
+                            <E7404513>Hermione</E7404513>
                             <E7404511>Granger</E7404511>
                             <E7404524>Grimmauld Place</E7404524>
                             <E7404540>77777</E7404540>
@@ -85,7 +85,7 @@
                         <Vorgang>01</Vorgang>
                         <StNr>1121081508150</StNr>
                         <Zeitraum>2022</Zeitraum>
-                        <AbsName>Hermine Granger</AbsName>
+                        <AbsName>Hermione Granger</AbsName>
                         <AbsStr>Grimmauld Place</AbsStr>
                         <AbsPlz>77777</AbsPlz>
                         <AbsOrt>London</AbsOrt>


### PR DESCRIPTION
# Short Description
Improve json-to-xml conversion testing as a prerequisite for further development of the Grundsteuer API.

# Changes
- Use json string as input instead of a Python dict to reflect the request payload more closely.
- Use the xmldiff library to compare expected and actual xml data for improved reliability and more useful output on failure.
- Fix typo in a certain Ms. Granger's name :)

