### PR TITLE
Queue/timestamps with sqlalchemy

### DIFF
--- a/erica/application/JobService/job_service.py
+++ b/erica/application/JobService/job_service.py
@@ -48,9 +48,7 @@ class JobService(JobServiceInterface):
     def add_to_queue(self, payload_dto: BaseDto, job_type: RequestType) -> EricaAuftragDto:
         request_entity = EricaRequest(job_id=uuid4(),
                                       payload=self.payload_type.parse_obj(payload_dto),
-                                      created_at=datetime.datetime.now(),
-                                      updated_at=datetime.datetime.now(),
-                                      creator_id="api",
+creator_id="api",
                                       type=job_type
                                       )
 

--- a/erica/domain/Shared/BaseDomainModel.py
+++ b/erica/domain/Shared/BaseDomainModel.py
@@ -8,7 +8,7 @@ ClassT = TypeVar('ClassT')
 
 
 class AuditedModel(BaseModel):
-    created_at: datetime.datetime
+    created_at: Optional[datetime.datetime]
     updated_at: Optional[datetime.datetime]
     creator_id: str
 

--- a/erica/domain/erica_request/erica_request.py
+++ b/erica/domain/erica_request/erica_request.py
@@ -18,7 +18,7 @@ class EricaRequest(BaseDomainModel[UUID]):
     status: Status = Status.new
     payload: object
     job_id: UUID
-    elster_request_id: Optional[str] = None
+    result: Optional[object]
 
     class Config:
         orm_mode = True

--- a/erica/infrastructure/sqlalchemy/base_schema.py
+++ b/erica/infrastructure/sqlalchemy/base_schema.py
@@ -1,8 +1,14 @@
 import sqlalchemy
 from sqlalchemy import Column, String
+from sqlalchemy.sql.functions import current_timestamp
 
 
 class AuditedSchemaMixin(object):
-    created_at = Column(sqlalchemy.types.DateTime)
-    updated_at = Column(sqlalchemy.types.DateTime)
+    created_at = Column(sqlalchemy.types.DateTime(timezone=True),
+                        default=current_timestamp(),
+                        nullable=False)
+    updated_at = Column(sqlalchemy.types.DateTime(timezone=True),
+                        default=current_timestamp(),
+                        onupdate=current_timestamp(),
+                        nullable=False)
     creator_id = Column(String)

--- a/erica/infrastructure/sqlalchemy/erica_request_schema.py
+++ b/erica/infrastructure/sqlalchemy/erica_request_schema.py
@@ -16,6 +16,6 @@ class EricaRequestSchema(AuditedSchemaMixin, BaseDbSchema):
                 primary_key=True)
     type = Column(Enum(RequestType))
     payload = Column(JSONB)
+    result = Column(JSONB)
     job_id = Column(UUID(as_uuid=True))
-    elster_request_id = Column(String, nullable=True)
     status = Column(Enum(Status))

--- a/erica/infrastructure/sqlalchemy/repositories/base_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/base_repository.py
@@ -54,6 +54,8 @@ class BaseRepository(BaseRepositoryInterface[T], Generic[T, D]):
 
     def update(self, entity_id: Integer, model: BaseModel) -> T:
         current = self._get_by_id(entity_id)
+        if current.first() is None:
+            raise EntityNotFoundError
         current.update(model.dict())
         self.db_connection.commit()
 

--- a/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
@@ -38,11 +38,7 @@ class EricaRequestRepository(
             raise EntityNotFoundError
 
         # We only want to run update with changed data
-        updated_data = {}
-        for key, value in model.dict().items():
-            if hasattr(current_entity, key) and value != getattr(current_entity, key):
-                updated_data[key] = value
-        current_query.update(updated_data)
+        current_query.update(self._get_changed_data(current_query.first(), model))
         self.db_connection.commit()
 
         updated = self.get_by_job_id(job_id)

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -82,8 +82,8 @@ class TestJobServiceQueue:
             id="1234",
             job_id="00000000-0000-0000-0000-000000000000",
             payload=input_data,
-            created_at=datetime.now().__str__(),
-            updated_at=datetime.now().__str__(),
+            created_at=None,
+            updated_at=None,
             creator_id="api",
             type=RequestType.freischalt_code_activate
         )

--- a/tests/infrastructure/sqlalechemy/repositories/mock_repositories.py
+++ b/tests/infrastructure/sqlalechemy/repositories/mock_repositories.py
@@ -1,3 +1,6 @@
+import uuid
+from typing import Optional
+
 from pydantic import BaseModel
 from sqlalchemy import Column, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
@@ -6,6 +9,7 @@ from erica.infrastructure.sqlalchemy.erica_request_schema import BaseDbSchema
 
 
 class MockDomainModel(BaseModel):
+    job_id: Optional[uuid.UUID]
     payload: dict
 
     class Config:

--- a/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
@@ -1,5 +1,6 @@
 from abc import ABC
-from uuid import uuid4
+from unittest.mock import MagicMock, call
+from uuid import uuid4, UUID
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -128,6 +129,28 @@ class TestBaseRepositoryUpdate:
 
         with pytest.raises(EntityNotFoundError):
             MockBaseRepository(db_connection=transactional_session).update(schema_object.id, updated_object)
+
+    @pytest.mark.freeze_uuids
+    def test_if_only_job_id_changed_then_only_call_update_with_changed_attributes(self, transactional_session):
+        mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
+        schema_object = MockSchema(**mock_object.dict())
+        transactional_session.add(schema_object)
+        transactional_session.commit()
+
+        updated_object = MockDomainModel(job_id=uuid4(),
+                                         payload={'endboss': 'Melkor'})
+
+        # We need a mock object to be able to intercept the call to the update function
+        repo = MockBaseRepository(db_connection=transactional_session)
+        update_mock = MagicMock()
+        mocked_get_by_id = MagicMock(side_effect=lambda entity_id: MagicMock(
+            first=MagicMock(return_value=MockBaseRepository(db_connection=transactional_session)._get_by_id(entity_id).first()),
+            update=update_mock))
+        repo._get_by_id = mocked_get_by_id
+
+        repo.update(schema_object.id, updated_object)
+
+        assert update_mock.mock_calls == [call({'job_id': UUID('00000000-0000-0000-0000-000000000000')})]
 
 
 class TestBaseRepositoryDelete:

--- a/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
@@ -88,7 +88,8 @@ class TestBaseRepositoryGetById:
 
     def test_if_entity_not_in_database_then_raise_exception(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
-        schema_object = MockSchema(**mock_object.dict(), job_id=uuid4())
+        mock_object.job_id = uuid4()
+        schema_object = MockSchema(**mock_object.dict())
 
         with pytest.raises(EntityNotFoundError):
             MockBaseRepository(db_connection=transactional_session).get_by_id(schema_object.id)

--- a/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
@@ -1,16 +1,22 @@
+import datetime
 from uuid import uuid4
 
 import pytest
+import pytest_pgsql
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import database_exists, create_database
 
+from erica.domain.Shared.EricaAuftrag import RequestType
+from erica.domain.Shared.Status import Status
+from erica.domain.erica_request.erica_request import EricaRequest
 from erica.infrastructure.sqlalchemy.database import get_engine, run_migrations
+from erica.infrastructure.sqlalchemy.erica_request_schema import EricaRequestSchema
 from erica.infrastructure.sqlalchemy.repositories.base_repository import EntityNotFoundError
 from erica.infrastructure.sqlalchemy.repositories.erica_request_repository import EricaRequestRepository
 from tests.infrastructure.sqlalechemy.repositories.mock_repositories import MockDomainModel, MockSchema
 
 
-class MockEricaRequstRepository(
+class MockEricaRequestRepository(
     EricaRequestRepository
 ):
     def __init__(self, db_connection):
@@ -19,10 +25,44 @@ class MockEricaRequstRepository(
         self.DomainModel = MockDomainModel
 
 
+
 @pytest.fixture
 def transactional_session(transacted_postgresql_db):
     transacted_postgresql_db.create_table(MockSchema)
     yield transacted_postgresql_db.session
+
+@pytest.fixture
+def transactional_erica_request_session():
+    if not database_exists(get_engine().url):
+        create_database(get_engine().url)
+    run_migrations()
+    session = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())()
+    yield session
+
+    tables = MockSchema.metadata.sorted_tables
+    for table in tables:
+        session.execute(table.delete())
+    session.commit()
+
+
+class TestEricaRepositoryCreate:
+
+    @pytest_pgsql.freeze_time(datetime.datetime(2001, 1, 3, 8, 22, 0, tzinfo=datetime.timezone.utc))
+    def test_if_create_object_then_set_timestamps_to_now(self, transacted_postgresql_db):
+        transacted_postgresql_db.create_table(EricaRequestSchema)
+        job_id = uuid4()
+        mock_object = EricaRequest(job_id=job_id,
+                                   payload={'endboss': 'Melkor'},
+                                   creator_id="api",
+                                   type=RequestType.freischalt_code_request,
+                                   status=Status.new)
+
+        EricaRequestRepository(db_connection=transacted_postgresql_db.session).create(mock_object)
+
+        found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id == job_id).first()
+
+        assert found_entity.created_at.timestamp() == datetime.datetime.utcnow().timestamp()
+        assert found_entity.updated_at.timestamp() == datetime.datetime.utcnow().timestamp()
 
 
 class TestEricaRepositoryGetByJobId:
@@ -30,11 +70,12 @@ class TestEricaRepositoryGetByJobId:
     def test_if_entity_in_database_then_return_domain_representation(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
         job_id = uuid4()
-        schema_object = MockSchema(**mock_object.dict(), job_id=job_id)
+        mock_object.job_id = job_id
+        schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        found_entity = MockEricaRequstRepository(db_connection=transactional_session).get_by_job_id(job_id)
+        found_entity = MockEricaRequestRepository(db_connection=transactional_session).get_by_job_id(job_id)
 
         assert found_entity == mock_object
 
@@ -42,7 +83,7 @@ class TestEricaRepositoryGetByJobId:
         job_id = uuid4()
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequstRepository(db_connection=transactional_session).get_by_job_id(job_id)
+            MockEricaRequestRepository(db_connection=transactional_session).get_by_job_id(job_id)
 
 
 class TestEricaRepositoryUpdateByJobId:
@@ -54,7 +95,7 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        updated_entity = MockEricaRequstRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+        updated_entity = MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
 
         assert updated_entity == updated_object
 
@@ -65,7 +106,7 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        MockEricaRequstRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+        MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
 
         updated_entry_in_db = transactional_session.query(MockSchema).filter(MockSchema.job_id == schema_object.job_id).first()
         assert updated_entry_in_db.job_id == schema_object.job_id
@@ -77,7 +118,27 @@ class TestEricaRepositoryUpdateByJobId:
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequstRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+            MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+
+    def test_if_update_object_then_set_only_updated_at_timestamp(self, transactional_erica_request_session):
+        job_id = uuid4()
+        mock_object = EricaRequest(job_id=job_id,
+                                   payload={'endboss': 'Melkor'},
+                                   creator_id="api",
+                                   type=RequestType.freischalt_code_request,
+                                   status=Status.new)
+        created_object = EricaRequestRepository(db_connection=transactional_erica_request_session).create(mock_object)
+        found_entity_before_update = transactional_erica_request_session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id == job_id).first()
+        before_update_created_at_timestamp = found_entity_before_update.created_at
+        before_update_updated_at_timestamp = found_entity_before_update.updated_at
+        created_object.payload = {'endboss': 'Sauron'}
+
+        EricaRequestRepository(db_connection=transactional_erica_request_session).update_by_job_id(job_id, created_object)
+
+        found_entity = transactional_erica_request_session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id == job_id).first()
+
+        assert found_entity.created_at == before_update_created_at_timestamp
+        assert found_entity.updated_at > before_update_updated_at_timestamp
 
 
 class TestEricaRepositoryDeleteByJobId:
@@ -88,7 +149,7 @@ class TestEricaRepositoryDeleteByJobId:
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        MockEricaRequstRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)
+        MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)
 
         not_found_entry = transactional_session.query(MockSchema).filter(MockSchema.job_id == schema_object.job_id).first()
         assert not_found_entry is None
@@ -98,4 +159,4 @@ class TestEricaRepositoryDeleteByJobId:
         schema_object = MockSchema(**mock_object.dict())
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequstRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)
+            MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)


### PR DESCRIPTION
# Short Description
We do not need to set timestamps for the entities ourselves but let the database handle this. This adds exactly that. However, `onupdate` will only be called if no value is provided. Therefore, we strip all the values from the input to the update function that have not changed.

# Changes
- Use SQLAlchemy to set the correct timestamps

# Feedback
- Do you think the tests are at the correct place or should they be placed somewhere else?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
