### PR TITLE
Add failure status to database entity for failed jobs

### DIFF
--- a/erica/application/EricaAuftrag/EricaAuftrag.py
+++ b/erica/application/EricaAuftrag/EricaAuftrag.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from uuid import UUID
 
 from pydantic.main import BaseModel
@@ -15,4 +16,6 @@ class EricaAuftragDto(BaseModel):
     status: Status = Status.new
     payload: object
     job_id: UUID
-    elster_request_id: str = None
+    result: Optional[object]
+    error_code: Optional[str]
+    error_message: Optional[str]

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -41,6 +41,8 @@ async def perform_job(entity_id: UUID, repository: base_repository_interface, se
                 f"Job failed: {entity}. Got Error Message: {e.generate_error_response(True).__str__()}",
                 exc_info=True
             )
+            entity.status = Status.failed
+            repository.update(entity.id, entity)
             raise
 
         logger.info(f"Job finished: {entity}", exc_info=True)

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -41,6 +41,8 @@ async def perform_job(entity_id: UUID, repository: base_repository_interface, se
                 f"Job failed: {entity}. Got Error Message: {e.generate_error_response(True).__str__()}",
                 exc_info=True
             )
+            entity.error_code = e.generate_error_response().get('code')
+            entity.error_message = e.generate_error_response().get('message')
             entity.status = Status.failed
             repository.update(entity.id, entity)
             raise

--- a/erica/application/JobService/job_service.py
+++ b/erica/application/JobService/job_service.py
@@ -48,7 +48,7 @@ class JobService(JobServiceInterface):
     def add_to_queue(self, payload_dto: BaseDto, job_type: RequestType) -> EricaAuftragDto:
         request_entity = EricaRequest(job_id=uuid4(),
                                       payload=self.payload_type.parse_obj(payload_dto),
-creator_id="api",
+                                      creator_id="api",
                                       type=job_type
                                       )
 
@@ -57,12 +57,12 @@ creator_id="api",
         self.background_worker.enqueue(
             created.id,
             f=self.job_method,
-            retry=Retry(max=3, interval=1),
             job_id=request_entity.job_id.__str__(),
         )
 
         return EricaAuftragDto.parse_obj(created)
 
     async def apply_to_elster(self, payload_data, include_elster_responses: bool = False):
-        controller = self.request_controller(payload_data, include_elster_responses) # TODO check if we can directly inject the class
+        controller = self.request_controller(payload_data,
+                                             include_elster_responses)
         return controller.process()

--- a/erica/domain/erica_request/erica_request.py
+++ b/erica/domain/erica_request/erica_request.py
@@ -19,6 +19,8 @@ class EricaRequest(BaseDomainModel[UUID]):
     payload: object
     job_id: UUID
     result: Optional[object]
+    error_code: Optional[str]
+    error_message: Optional[str]
 
     class Config:
         orm_mode = True

--- a/erica/infrastructure/sqlalchemy/erica_request_schema.py
+++ b/erica/infrastructure/sqlalchemy/erica_request_schema.py
@@ -19,3 +19,5 @@ class EricaRequestSchema(AuditedSchemaMixin, BaseDbSchema):
     result = Column(JSONB)
     job_id = Column(UUID(as_uuid=True))
     status = Column(Enum(Status))
+    error_code = Column(String, nullable=True)
+    error_message = Column(String, nullable=True)

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -44,6 +44,8 @@ class TestJob:
         with pytest.raises(EricProcessNotSuccessful):
             await perform_job(entity_id=uuid4(), repository=mock_repository, service=mock_service, dto=MagicMock(), logger=MagicMock())
 
+        assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('code')
+        assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
         assert mock_entity.status == Status.failed
         assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
 

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -92,17 +92,14 @@ class TestJobServiceQueue:
     def test_if_input_data_provided_then_add_job_to_background_job_worker_with_correct_params(self):
         mock_job = PickableMock()
         mock_bg_worker = MagicMock()
-        mock_retry = MagicMock(return_value="retry")
         service = JobService(job_repository=MockEricaRequestRepository(), background_worker=mock_bg_worker,
                              request_controller=MockRequestController, payload_type=MockDto, job_method=mock_job)
         input_data = MockDto.parse_obj({'name': 'Batman', 'friend': 'Joker'})
 
-        with patch('erica.application.JobService.job_service.Retry', mock_retry):
-            # TODO we have some dependency on the Retry object inside the service which should only be part of the infrastructure I think, so we should probably remove that
-            service.add_to_queue(input_data, job_type=RequestType.freischalt_code_activate)
+        service.add_to_queue(input_data, job_type=RequestType.freischalt_code_activate)
 
         assert mock_bg_worker.enqueue.mock_calls == [
-            call("1234", f=mock_job, job_id="00000000-0000-0000-0000-000000000000", retry="retry")]
+            call("1234", f=mock_job, job_id="00000000-0000-0000-0000-000000000000")]
 
 
 class TestJobServiceRun:


### PR DESCRIPTION
# Short Description
This adds a failed status to an entity in the database if a job failed. For now, this happens in the job. However, if we want to use retries, we probably need to move that to a special exception handler.
This also adds the `error_code` and `error_message` to all EricaRequest classes and sets them if a job fails.

# Changes
- Remove retries from job creation
- Change status if an EricProcessNotSuccessfulError occurred in a job

# Feedback
- Do you see any part that needs to be adapted with the error_message & error_code part that is currently missing?
- Do you see any tests that I missed?