### PR TITLE
Add correct request UUID column

### DIFF
--- a/erica/application/EricaAuftrag/EricaAuftrag.py
+++ b/erica/application/EricaAuftrag/EricaAuftrag.py
@@ -15,7 +15,7 @@ class EricaAuftragDto(BaseModel):
     type: RequestType
     status: Status = Status.new
     payload: object
-    job_id: UUID
+    request_id: UUID
     result: Optional[object]
     error_code: Optional[str]
     error_message: Optional[str]

--- a/erica/application/FreischaltCode/Jobs/jobs.py
+++ b/erica/application/FreischaltCode/Jobs/jobs.py
@@ -4,30 +4,30 @@ from erica.application.JobService.job import perform_job
 from erica.domain.Shared.EricaAuftrag import RequestType
 
 
-async def request_freischalt_code(entity_id):
+async def request_freischalt_code(request_id):
     from erica.application.JobService.job_service_factory import get_job_service
     service = get_job_service(RequestType.freischalt_code_request)
-    await perform_job(entity_id=entity_id,
+    await perform_job(request_id=request_id,
                 repository=service.repository,
                 service=service,
                 dto=service.payload_type,
                 logger=logging.getLogger())
 
 
-async def activate_freischalt_code(entity_id):
+async def activate_freischalt_code(request_id):
     from erica.application.JobService.job_service_factory import get_job_service
     service = get_job_service(RequestType.freischalt_code_activate)
-    await perform_job(entity_id=entity_id,
+    await perform_job(request_id=request_id,
                 repository=service.repository,
                 service=service,
                 dto=service.payload_type,
                 logger=logging.getLogger())
 
 
-async def revocate_freischalt_code(entity_id):
+async def revocate_freischalt_code(request_id):
     from erica.application.JobService.job_service_factory import get_job_service
     service = get_job_service(RequestType.freischalt_code_revocate)
-    await perform_job(entity_id=entity_id,
+    await perform_job(request_id=request_id,
                 repository=service.repository,
                 service=service,
                 dto=service.payload_type,

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -20,9 +20,9 @@ async def perform_job(entity_id: UUID, repository: base_repository_interface, se
     It also measures the elapsed time during job execution.
     """
     try:
-        entity: EricaRequest = repository.get_by_job_id(entity_id)
+        entity: EricaRequest = repository.get_by_job_request_id(entity_id)
     except EntityNotFoundError:
-        logger.warning(f"Entity not found for job_id {entity_id}", exc_info=True)
+        logger.warning(f"Entity not found for request_id {entity_id}", exc_info=True)
         raise
 
     request_payload: dto = dto.parse_obj(entity.payload)

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -12,7 +12,7 @@ from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful
 from erica.infrastructure.sqlalchemy.repositories.base_repository import EntityNotFoundError
 
 
-async def perform_job(entity_id: UUID, repository: base_repository_interface, service: JobServiceInterface, dto: Type[BaseDto], logger: Logger):
+async def perform_job(request_id: UUID, repository: base_repository_interface, service: JobServiceInterface, dto: Type[BaseDto], logger: Logger):
     """
     The basic implementation for a job that is put on the Erica queue. It will get an entity, interact with the ERiC
     library using the service and then update the entity according to the result from the service.
@@ -20,9 +20,9 @@ async def perform_job(entity_id: UUID, repository: base_repository_interface, se
     It also measures the elapsed time during job execution.
     """
     try:
-        entity: EricaRequest = repository.get_by_job_request_id(entity_id)
+        entity: EricaRequest = repository.get_by_job_request_id(request_id)
     except EntityNotFoundError:
-        logger.warning(f"Entity not found for request_id {entity_id}", exc_info=True)
+        logger.warning(f"Entity not found for request_id {request_id}", exc_info=True)
         raise
 
     request_payload: dto = dto.parse_obj(entity.payload)

--- a/erica/application/JobService/job_service.py
+++ b/erica/application/JobService/job_service.py
@@ -46,7 +46,7 @@ class JobService(JobServiceInterface):
         self.job_method = job_method
 
     def add_to_queue(self, payload_dto: BaseDto, job_type: RequestType) -> EricaAuftragDto:
-        request_entity = EricaRequest(job_id=uuid4(),
+        request_entity = EricaRequest(request_id=uuid4(),
                                       payload=self.payload_type.parse_obj(payload_dto),
                                       creator_id="api",
                                       type=job_type
@@ -57,7 +57,7 @@ class JobService(JobServiceInterface):
         self.background_worker.enqueue(
             created.id,
             f=self.job_method,
-            job_id=request_entity.job_id.__str__(),
+            job_id=request_entity.request_id.__str__(),
         )
 
         return EricaAuftragDto.parse_obj(created)

--- a/erica/application/JobService/job_service.py
+++ b/erica/application/JobService/job_service.py
@@ -56,8 +56,7 @@ class JobService(JobServiceInterface):
 
         self.background_worker.enqueue(
             created.id,
-            f=self.job_method,
-            job_id=request_entity.request_id.__str__(),
+            f=self.job_method
         )
 
         return EricaAuftragDto.parse_obj(created)

--- a/erica/application/JobService/job_service.py
+++ b/erica/application/JobService/job_service.py
@@ -55,7 +55,7 @@ class JobService(JobServiceInterface):
         created = self.repository.create(request_entity)
 
         self.background_worker.enqueue(
-            created.id,
+            created.request_id,
             f=self.job_method
         )
 

--- a/erica/application/tax_number_validation/jobs.py
+++ b/erica/application/tax_number_validation/jobs.py
@@ -4,10 +4,10 @@ from erica.application.JobService.job import perform_job
 from erica.domain.Shared.EricaAuftrag import RequestType
 
 
-async def check_tax_number(entity_id):
+async def check_tax_number(request_id):
     from erica.application.JobService.job_service_factory import get_job_service
     service = get_job_service(RequestType.check_tax_number)
-    await perform_job(entity_id=entity_id,
+    await perform_job(request_id=request_id,
                 repository=service.repository,
                 service=service,
                 dto=service.payload_type,

--- a/erica/domain/erica_request/erica_request.py
+++ b/erica/domain/erica_request/erica_request.py
@@ -17,7 +17,7 @@ class EricaRequest(BaseDomainModel[UUID]):
     type: RequestType
     status: Status = Status.new
     payload: object
-    job_id: UUID
+    request_id: UUID
     result: Optional[object]
     error_code: Optional[str]
     error_message: Optional[str]
@@ -26,4 +26,4 @@ class EricaRequest(BaseDomainModel[UUID]):
         orm_mode = True
 
     def __str__(self):
-        return f"EricaAuftrag(type={self.type}, job_id={self.job_id}, status={self.status}"
+        return f"EricaAuftrag(type={self.type}, request_id={self.request_id}, status={self.status}"

--- a/erica/domain/repositories/base_repository_interface.py
+++ b/erica/domain/repositories/base_repository_interface.py
@@ -18,7 +18,7 @@ class BaseRepositoryInterface(Generic[ClassT]):
         pass
 
     @abstractmethod
-    def get_by_id(self, entity_id) -> ClassT:
+    def get_by_id(self, request_id) -> ClassT:
         pass
 
     @abstractmethod
@@ -26,7 +26,7 @@ class BaseRepositoryInterface(Generic[ClassT]):
         pass
 
     @abstractmethod
-    def delete(self, entity_id) -> bool:
+    def delete(self, request_id) -> bool:
         pass
 
 

--- a/erica/domain/repositories/base_repository_interface.py
+++ b/erica/domain/repositories/base_repository_interface.py
@@ -22,10 +22,6 @@ class BaseRepositoryInterface(Generic[ClassT]):
         pass
 
     @abstractmethod
-    def get_by_job_id(self, job_id) -> ClassT:
-        pass
-
-    @abstractmethod
     def update(self, model_id, model: ClassT) -> ClassT:
         pass
 

--- a/erica/domain/repositories/erica_request_repository_interface.py
+++ b/erica/domain/repositories/erica_request_repository_interface.py
@@ -10,17 +10,17 @@ from erica.domain.erica_request.erica_request import EricaRequest
 class EricaRequestRepositoryInterface(BaseRepositoryInterface[EricaRequest], ABC):
 
     @abstractmethod
-    def get_by_job_id(self, job_id: UUID) -> EricaRequest:
+    def get_by_job_request_id(self, request_id: UUID) -> EricaRequest:
         pass
 
     @abstractmethod
-    def _get_by_job_id(self, job_id: UUID):
+    def _get_by_job_request_id(self, request_id: UUID):
         pass
 
     @abstractmethod
-    def update_by_job_id(self, job_id: UUID, model: BaseModel) -> EricaRequest:
+    def update_by_job_request_id(self, request_id: UUID, model: BaseModel) -> EricaRequest:
         pass
 
     @abstractmethod
-    def delete_by_job_id(self, job_id: UUID):
+    def delete_by_job_request_id(self, request_id: UUID):
         pass

--- a/erica/infrastructure/sqlalchemy/erica_request_schema.py
+++ b/erica/infrastructure/sqlalchemy/erica_request_schema.py
@@ -17,7 +17,7 @@ class EricaRequestSchema(AuditedSchemaMixin, BaseDbSchema):
     type = Column(Enum(RequestType))
     payload = Column(JSONB)
     result = Column(JSONB)
-    job_id = Column(UUID(as_uuid=True))
+    request_id = Column(UUID(as_uuid=True))
     status = Column(Enum(Status))
     error_code = Column(String, nullable=True)
     error_message = Column(String, nullable=True)

--- a/erica/infrastructure/sqlalchemy/repositories/base_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/base_repository.py
@@ -42,15 +42,15 @@ class BaseRepository(BaseRepositoryInterface[T], Generic[T, D]):
         result = self.db_connection.query(self.DatabaseEntity).offset(skip).limit(limit).all()
         return result
 
-    def get_by_id(self, entity_id: Integer) -> T:
-        entity = self._get_by_id(entity_id)
+    def get_by_id(self, request_id: Integer) -> T:
+        entity = self._get_by_id(request_id)
         entity = entity.first()
         if entity is None:
             raise EntityNotFoundError
         return self.DomainModel.from_orm(entity)
 
-    def _get_by_id(self, entity_id: Integer):
-        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.id == entity_id)
+    def _get_by_id(self, request_id: Integer):
+        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.id == request_id)
         return entity
 
     @staticmethod
@@ -62,18 +62,18 @@ class BaseRepository(BaseRepositoryInterface[T], Generic[T, D]):
 
         return updated_data
 
-    def update(self, entity_id: Integer, model: BaseModel) -> T:
-        current = self._get_by_id(entity_id)
+    def update(self, request_id: Integer, model: BaseModel) -> T:
+        current = self._get_by_id(request_id)
         if current.first() is None:
             raise EntityNotFoundError
         current.update(self._get_changed_data(old_entity=current.first(), updated_entity=model))
         self.db_connection.commit()
 
-        updated = self.get_by_id(entity_id)
+        updated = self.get_by_id(request_id)
         return self.DomainModel.from_orm(updated)
 
-    def delete(self, entity_id: Integer):
-        entity = self._get_by_id(entity_id).first()
+    def delete(self, request_id: Integer):
+        entity = self._get_by_id(request_id).first()
         if entity is None:
             raise EntityNotFoundError
         self.db_connection.delete(entity)

--- a/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
@@ -21,18 +21,18 @@ class EricaRequestRepository(
         self.DatabaseEntity = EricaRequestSchema
         self.DomainModel = EricaRequest
 
-    def get_by_job_id(self, job_id: UUID) -> EricaRequest:
-        entity = self._get_by_job_id(job_id).first()
+    def get_by_job_request_id(self, request_id: UUID) -> EricaRequest:
+        entity = self._get_by_job_request_id(request_id).first()
         if entity is None:
             raise EntityNotFoundError
         return self.DomainModel.from_orm(entity)
 
-    def _get_by_job_id(self, job_id: UUID):
-        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.request_id == job_id)
+    def _get_by_job_request_id(self, request_id: UUID):
+        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.request_id == request_id)
         return entity
 
-    def update_by_job_id(self, job_id: UUID, model: BaseModel) -> EricaRequest:
-        current_query = self._get_by_job_id(job_id)
+    def update_by_job_request_id(self, request_id: UUID, model: BaseModel) -> EricaRequest:
+        current_query = self._get_by_job_request_id(request_id)
         current_entity = current_query.first()
         if current_entity is None:
             raise EntityNotFoundError
@@ -41,11 +41,11 @@ class EricaRequestRepository(
         current_query.update(self._get_changed_data(current_query.first(), model))
         self.db_connection.commit()
 
-        updated = self.get_by_job_id(job_id)
+        updated = self.get_by_job_request_id(request_id)
         return self.DomainModel.from_orm(updated)
 
-    def delete_by_job_id(self, job_id: UUID):
-        entity = self._get_by_job_id(job_id).first()
+    def delete_by_job_request_id(self, request_id: UUID):
+        entity = self._get_by_job_request_id(request_id).first()
         if entity is None:
             raise EntityNotFoundError
 

--- a/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
@@ -28,7 +28,7 @@ class EricaRequestRepository(
         return self.DomainModel.from_orm(entity)
 
     def _get_by_job_id(self, job_id: UUID):
-        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.job_id == job_id)
+        entity = self.db_connection.query(self.DatabaseEntity).filter(self.DatabaseEntity.request_id == job_id)
         return entity
 
     def update_by_job_id(self, job_id: UUID, model: BaseModel) -> EricaRequest:

--- a/tests/application/FreischaltCode/test_freischaltcode_jobs.py
+++ b/tests/application/FreischaltCode/test_freischaltcode_jobs.py
@@ -13,13 +13,13 @@ class TestRequestFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_perform_job_called_with_correct_parameters(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()) as mock_perform_job:
-            await request_freischalt_code(entity_id)
+            await request_freischalt_code(request_id)
 
-            assert mock_perform_job.mock_calls == [call(entity_id=entity_id,
+            assert mock_perform_job.mock_calls == [call(request_id=request_id,
                                                         repository=mock_get_service().repository,
                                                         service=mock_get_service(),
                                                         logger=logging.getLogger(),
@@ -27,11 +27,11 @@ class TestRequestFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_get_job_service_called_with_correct_param(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()):
-            await request_freischalt_code(entity_id)
+            await request_freischalt_code(request_id)
 
             assert mock_get_service.mock_calls == [call(RequestType.freischalt_code_request)]
 
@@ -59,13 +59,13 @@ class TestActivateFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_perform_job_called_with_correct_parameters(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()) as mock_perform_job:
-            await activate_freischalt_code(entity_id)
+            await activate_freischalt_code(request_id)
 
-            assert mock_perform_job.mock_calls == [call(entity_id=entity_id,
+            assert mock_perform_job.mock_calls == [call(request_id=request_id,
                                                         repository=mock_get_service().repository,
                                                         service=mock_get_service(),
                                                         logger=logging.getLogger(),
@@ -73,11 +73,11 @@ class TestActivateFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_get_job_service_called_with_correct_param(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()):
-            await activate_freischalt_code(entity_id)
+            await activate_freischalt_code(request_id)
 
             assert mock_get_service.mock_calls == [call(RequestType.freischalt_code_activate)]
 
@@ -105,13 +105,13 @@ class TestRevocateFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_perform_job_called_with_correct_parameters(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()) as mock_perform_job:
-            await revocate_freischalt_code(entity_id)
+            await revocate_freischalt_code(request_id)
 
-            assert mock_perform_job.mock_calls == [call(entity_id=entity_id,
+            assert mock_perform_job.mock_calls == [call(request_id=request_id,
                                                         repository=mock_get_service().repository,
                                                         service=mock_get_service(),
                                                         logger=logging.getLogger(),
@@ -119,11 +119,11 @@ class TestRevocateFreischaltcode:
 
     @pytest.mark.asyncio
     async def test_get_job_service_called_with_correct_param(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.FreischaltCode.Jobs.jobs.perform_job", AsyncMock()):
-            await revocate_freischalt_code(entity_id)
+            await revocate_freischalt_code(request_id)
 
             assert mock_get_service.mock_calls == [call(RequestType.freischalt_code_revocate)]
 

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -35,7 +35,7 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_service_raises_error_then_update_entity_in_database_with_correct_values(self):
-        mock_entity = MagicMock(id="R2-D2", job_id="C3PO")
+        mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
         mock_get_by_job_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
         mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
@@ -96,7 +96,7 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_entity_exists_then_call_service_with_parsed_entity_payload_and_include_elster_response_true(self):
-        mock_entity = MagicMock(id="R2-D2", job_id="C3PO")
+        mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
         mock_repository = MagicMock(get_by_job_id=MagicMock(return_value=mock_entity))
         dto_parse_obj = MagicMock()
         mock_apply_to_elster = AsyncMock()
@@ -108,7 +108,7 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_job_ran_successful_then_update_entity_in_database_with_correct_values(self):
-        mock_entity = MagicMock(id="R2-D2", job_id="C3PO")
+        mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
         mock_get_by_job_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
         mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
@@ -126,7 +126,7 @@ class TestJob:
         original_id = "R2-D2"
         original_job_id = "C3P0"
         original_type = "droid"
-        mock_entity = MagicMock(id=original_id, job_id=original_job_id, type=original_type)
+        mock_entity = MagicMock(id=original_id, request_id=original_job_id, type=original_type)
         mock_get_by_job_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
         mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
@@ -136,7 +136,7 @@ class TestJob:
         await perform_job(entity_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
 
         assert mock_entity.id == original_id
-        assert mock_entity.job_id == original_job_id
+        assert mock_entity.request_id == original_job_id
         assert mock_entity.type == original_type
 
     @pytest.mark.asyncio

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -36,9 +36,9 @@ class TestJob:
     @pytest.mark.asyncio
     async def test_if_service_raises_error_then_update_entity_in_database_with_correct_values(self):
         mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
-        mock_get_by_job_id = MagicMock(return_value=mock_entity)
+        mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
-        mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
         mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricProcessNotSuccessful))
 
         with pytest.raises(EricProcessNotSuccessful):
@@ -65,16 +65,16 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_entity_not_found_then_raise_error(self):
-        mock_get_by_job_id = MagicMock(side_effect=EntityNotFoundError)
-        mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id)
+        mock_get_by_job_request_id = MagicMock(side_effect=EntityNotFoundError)
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id)
 
         with pytest.raises(EntityNotFoundError):
             await perform_job(entity_id=uuid4(), repository=mock_repository, service=AsyncMock(), dto=MagicMock(), logger=MagicMock())
 
     @pytest.mark.asyncio
     async def test_if_entity_not_found_then_log_error_in_warning_logger(self):
-        mock_get_by_job_id = MagicMock(side_effect=EntityNotFoundError)
-        mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id)
+        mock_get_by_job_request_id = MagicMock(side_effect=EntityNotFoundError)
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id)
         warning_logger = MagicMock()
         logger = MagicMock(warning=warning_logger)
         entity_id = uuid4()
@@ -97,7 +97,7 @@ class TestJob:
     @pytest.mark.asyncio
     async def test_if_entity_exists_then_call_service_with_parsed_entity_payload_and_include_elster_response_true(self):
         mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
-        mock_repository = MagicMock(get_by_job_id=MagicMock(return_value=mock_entity))
+        mock_repository = MagicMock(get_by_job_request_id=MagicMock(return_value=mock_entity))
         dto_parse_obj = MagicMock()
         mock_apply_to_elster = AsyncMock()
         service = MagicMock(apply_to_elster=mock_apply_to_elster)
@@ -109,9 +109,9 @@ class TestJob:
     @pytest.mark.asyncio
     async def test_if_job_ran_successful_then_update_entity_in_database_with_correct_values(self):
         mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
-        mock_get_by_job_id = MagicMock(return_value=mock_entity)
+        mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
-        mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
         mock_result = "These are not the mocks you are looking for"
         service = MagicMock(apply_to_elster=AsyncMock(return_value=mock_result))
 
@@ -124,19 +124,19 @@ class TestJob:
     @pytest.mark.asyncio
     async def test_if_job_ran_successful_then_ids_type_and_payload_of_entity_not_changed(self):
         original_id = "R2-D2"
-        original_job_id = "C3P0"
+        original_request_id = "C3P0"
         original_type = "droid"
-        mock_entity = MagicMock(id=original_id, request_id=original_job_id, type=original_type)
-        mock_get_by_job_id = MagicMock(return_value=mock_entity)
+        mock_entity = MagicMock(id=original_id, request_id=original_request_id, type=original_type)
+        mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
-        mock_repository = MagicMock(get_by_job_id=mock_get_by_job_id, update=mock_update)
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
         mock_result = "These are not the mocks you are looking for"
         service = MagicMock(apply_to_elster=AsyncMock(return_value=mock_result))
 
         await perform_job(entity_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
 
         assert mock_entity.id == original_id
-        assert mock_entity.request_id == original_job_id
+        assert mock_entity.request_id == original_request_id
         assert mock_entity.type == original_type
 
     @pytest.mark.asyncio

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -19,7 +19,7 @@ class TestJob:
         mock_service = MagicMock(apply_to_elster=mock_apply_to_elster)
 
         with pytest.raises(EricProcessNotSuccessful):
-            await perform_job(entity_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=MagicMock())
+            await perform_job(request_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=MagicMock())
 
     @pytest.mark.asyncio
     async def test_if_service_raises_error_then_log_error_in_warning_logger(self):
@@ -29,7 +29,7 @@ class TestJob:
         logger = MagicMock(warning=warning_logger)
 
         with pytest.raises(EricProcessNotSuccessful):
-            await perform_job(entity_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=logger)
+            await perform_job(request_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=logger)
 
         assert any("Job failed" in logged_msg[1][0] for logged_msg in warning_logger.mock_calls)
 
@@ -42,7 +42,7 @@ class TestJob:
         mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricProcessNotSuccessful))
 
         with pytest.raises(EricProcessNotSuccessful):
-            await perform_job(entity_id=uuid4(), repository=mock_repository, service=mock_service, dto=MagicMock(), logger=MagicMock())
+            await perform_job(request_id=uuid4(), repository=mock_repository, service=mock_service, dto=MagicMock(), logger=MagicMock())
 
         assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('code')
         assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
@@ -58,7 +58,7 @@ class TestJob:
         logger = MagicMock(info=info_logger)
 
         with pytest.raises(EricProcessNotSuccessful):
-            await perform_job(entity_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=logger)
+            await perform_job(request_id=uuid4(), repository=MagicMock(), service=mock_service, dto=MagicMock(), logger=logger)
 
         assert any("Job running time" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)
         assert any(f"{timedelta(seconds=15)}" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)
@@ -69,7 +69,7 @@ class TestJob:
         mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id)
 
         with pytest.raises(EntityNotFoundError):
-            await perform_job(entity_id=uuid4(), repository=mock_repository, service=AsyncMock(), dto=MagicMock(), logger=MagicMock())
+            await perform_job(request_id=uuid4(), repository=mock_repository, service=AsyncMock(), dto=MagicMock(), logger=MagicMock())
 
     @pytest.mark.asyncio
     async def test_if_entity_not_found_then_log_error_in_warning_logger(self):
@@ -77,12 +77,12 @@ class TestJob:
         mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id)
         warning_logger = MagicMock()
         logger = MagicMock(warning=warning_logger)
-        entity_id = uuid4()
+        request_id = uuid4()
 
         with pytest.raises(EntityNotFoundError):
-            await perform_job(entity_id=entity_id, repository=mock_repository, service=AsyncMock(), dto=MagicMock(), logger=logger)
+            await perform_job(request_id=request_id, repository=mock_repository, service=AsyncMock(), dto=MagicMock(), logger=logger)
 
-        assert any(f"{entity_id}" in logged_msg[1][0] for logged_msg in warning_logger.mock_calls)
+        assert any(f"{request_id}" in logged_msg[1][0] for logged_msg in warning_logger.mock_calls)
         assert any("Entity not found" in logged_msg[1][0] for logged_msg in warning_logger.mock_calls)
 
     @pytest.mark.asyncio
@@ -90,7 +90,7 @@ class TestJob:
         info_logger = MagicMock()
         logger = MagicMock(info=info_logger)
 
-        await perform_job(entity_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
+        await perform_job(request_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
 
         assert any("Job started" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)
 
@@ -102,7 +102,7 @@ class TestJob:
         mock_apply_to_elster = AsyncMock()
         service = MagicMock(apply_to_elster=mock_apply_to_elster)
 
-        await perform_job(entity_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(parse_obj=dto_parse_obj), logger=MagicMock())
+        await perform_job(request_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(parse_obj=dto_parse_obj), logger=MagicMock())
 
         assert mock_apply_to_elster.mock_calls[0] == call(dto_parse_obj(mock_entity), True)
 
@@ -115,7 +115,7 @@ class TestJob:
         mock_result = "These are not the mocks you are looking for"
         service = MagicMock(apply_to_elster=AsyncMock(return_value=mock_result))
 
-        await perform_job(entity_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
+        await perform_job(request_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
 
         assert mock_entity.result == mock_result
         assert mock_entity.status == Status.success
@@ -133,7 +133,7 @@ class TestJob:
         mock_result = "These are not the mocks you are looking for"
         service = MagicMock(apply_to_elster=AsyncMock(return_value=mock_result))
 
-        await perform_job(entity_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
+        await perform_job(request_id=uuid4(), repository=mock_repository, service=service, dto=MagicMock(), logger=MagicMock())
 
         assert mock_entity.id == original_id
         assert mock_entity.request_id == original_request_id
@@ -144,7 +144,7 @@ class TestJob:
         info_logger = MagicMock()
         logger = MagicMock(info=info_logger)
 
-        await perform_job(entity_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
+        await perform_job(request_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
 
         assert any("Job finished" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)
 
@@ -154,7 +154,7 @@ class TestJob:
         info_logger = MagicMock()
         logger = MagicMock(info=info_logger)
 
-        await perform_job(entity_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
+        await perform_job(request_id=uuid4(), repository=MagicMock(), service=AsyncMock(), dto=MagicMock(), logger=logger)
 
         assert any("Job running time" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)
         assert any(f"{timedelta(seconds=15)}" in logged_msg[1][0] for logged_msg in info_logger.mock_calls)

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -29,8 +29,8 @@ class MockEricaRequestRepository(EricaRequestRepository, list):
     def get(self, skip: int = 0, limit: int = 100):
         return self
 
-    def get_by_id(self, entity_id):
-        return [entity for entity in self if entity.id == entity_id][0]
+    def get_by_id(self, request_id):
+        return [entity for entity in self if entity.id == request_id][0]
 
     def update(self, model_id, model):
         for entity, index in enumerate(self):
@@ -38,9 +38,9 @@ class MockEricaRequestRepository(EricaRequestRepository, list):
                 self[index] = model
         return model
 
-    def delete(self, entity_id):
+    def delete(self, request_id):
         for entity, index in enumerate(self):
-            if entity.id == entity_id:
+            if entity.id == request_id:
                 self.pop(index)
 
 

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from unittest.mock import Mock, MagicMock, call, patch
+from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
@@ -99,7 +100,7 @@ class TestJobServiceQueue:
         service.add_to_queue(input_data, job_type=RequestType.freischalt_code_activate)
 
         assert mock_bg_worker.enqueue.mock_calls == [
-            call("1234", f=mock_job)]
+            call(UUID('00000000-0000-0000-0000-000000000000'), f=mock_job)]
 
 
 class TestJobServiceRun:

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -99,7 +99,7 @@ class TestJobServiceQueue:
         service.add_to_queue(input_data, job_type=RequestType.freischalt_code_activate)
 
         assert mock_bg_worker.enqueue.mock_calls == [
-            call("1234", f=mock_job, job_id="00000000-0000-0000-0000-000000000000")]
+            call("1234", f=mock_job)]
 
 
 class TestJobServiceRun:

--- a/tests/application/job_service/test_job_service.py
+++ b/tests/application/job_service/test_job_service.py
@@ -80,7 +80,7 @@ class TestJobServiceQueue:
 
         assert service.repository[0] == EricaRequest(
             id="1234",
-            job_id="00000000-0000-0000-0000-000000000000",
+            request_id="00000000-0000-0000-0000-000000000000",
             payload=input_data,
             created_at=None,
             updated_at=None,
@@ -127,7 +127,7 @@ class TestJobServiceRun:
         input_data = MockDto.parse_obj({'name': 'Batman', 'friend': 'Joker'})
         request_entity = EricaRequest(
             id="1234",
-            job_id="00000000-0000-0000-0000-000000000000",
+            request_id="00000000-0000-0000-0000-000000000000",
             payload=input_data,
             created_at=datetime.now().__str__(),
             updated_at=datetime.now().__str__(),

--- a/tests/application/tax_number_validation/test_check_tax_number_jobs.py
+++ b/tests/application/tax_number_validation/test_check_tax_number_jobs.py
@@ -12,13 +12,13 @@ class TestCheckTaxNumber:
 
     @pytest.mark.asyncio
     async def test_perform_job_called_with_correct_parameters(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.tax_number_validation.jobs.perform_job", AsyncMock()) as mock_perform_job:
-            await check_tax_number(entity_id)
+            await check_tax_number(request_id)
 
-            assert mock_perform_job.mock_calls == [call(entity_id=entity_id,
+            assert mock_perform_job.mock_calls == [call(request_id=request_id,
                                                         repository=mock_get_service().repository,
                                                         service=mock_get_service(),
                                                         logger=logging.getLogger(),
@@ -26,11 +26,11 @@ class TestCheckTaxNumber:
 
     @pytest.mark.asyncio
     async def test_get_job_service_called_with_correct_param(self):
-        entity_id = "1234"
+        request_id = "1234"
 
         with patch("erica.application.JobService.job_service_factory.get_job_service", MagicMock()) as mock_get_service, \
                 patch("erica.application.tax_number_validation.jobs.perform_job", AsyncMock()):
-            await check_tax_number(entity_id)
+            await check_tax_number(request_id)
 
             assert mock_get_service.mock_calls == [call(RequestType.check_tax_number)]
 

--- a/tests/infrastructure/sqlalechemy/repositories/mock_repositories.py
+++ b/tests/infrastructure/sqlalechemy/repositories/mock_repositories.py
@@ -9,7 +9,7 @@ from erica.infrastructure.sqlalchemy.erica_request_schema import BaseDbSchema
 
 
 class MockDomainModel(BaseModel):
-    job_id: Optional[uuid.UUID]
+    request_id: Optional[uuid.UUID]
     payload: dict
 
     class Config:
@@ -21,5 +21,5 @@ class MockSchema(BaseDbSchema):
     id = Column(UUID(as_uuid=True),
                 primary_key=True,
                 server_default=text("gen_random_uuid()"), )
-    job_id = Column(UUID(as_uuid=True))
+    request_id = Column(UUID(as_uuid=True))
     payload = Column(JSONB)

--- a/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
@@ -140,8 +140,8 @@ class TestBaseRepositoryUpdate:
         # We need a mock object to be able to intercept the call to the update function
         repo = MockBaseRepository(db_connection=transactional_session)
         update_mock = MagicMock()
-        mocked_get_by_id = MagicMock(side_effect=lambda entity_id: MagicMock(
-            first=MagicMock(return_value=MockBaseRepository(db_connection=transactional_session)._get_by_id(entity_id).first()),
+        mocked_get_by_id = MagicMock(side_effect=lambda request_id: MagicMock(
+            first=MagicMock(return_value=MockBaseRepository(db_connection=transactional_session)._get_by_id(request_id).first()),
             update=update_mock))
         repo._get_by_id = mocked_get_by_id
 

--- a/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
@@ -3,11 +3,8 @@ from unittest.mock import MagicMock, call
 from uuid import uuid4, UUID
 
 import pytest
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy_utils import database_exists, create_database
 
 from erica.domain.repositories.base_repository_interface import BaseRepositoryInterface
-from erica.infrastructure.sqlalchemy.database import run_migrations
 from erica.infrastructure.sqlalchemy.repositories.base_repository import BaseRepository, EntityNotFoundError
 from tests.infrastructure.sqlalechemy.repositories.mock_repositories import MockDomainModel, MockSchema
 
@@ -89,7 +86,7 @@ class TestBaseRepositoryGetById:
 
     def test_if_entity_not_in_database_then_raise_exception(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
-        mock_object.job_id = uuid4()
+        mock_object.request_id = uuid4()
         schema_object = MockSchema(**mock_object.dict())
 
         with pytest.raises(EntityNotFoundError):
@@ -137,7 +134,7 @@ class TestBaseRepositoryUpdate:
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        updated_object = MockDomainModel(job_id=uuid4(),
+        updated_object = MockDomainModel(request_id=uuid4(),
                                          payload={'endboss': 'Melkor'})
 
         # We need a mock object to be able to intercept the call to the update function
@@ -150,7 +147,7 @@ class TestBaseRepositoryUpdate:
 
         repo.update(schema_object.id, updated_object)
 
-        assert update_mock.mock_calls == [call({'job_id': UUID('00000000-0000-0000-0000-000000000000')})]
+        assert update_mock.mock_calls == [call({'request_id': UUID('00000000-0000-0000-0000-000000000000')})]
 
 
 class TestBaseRepositoryDelete:

--- a/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_base_repository.py
@@ -128,7 +128,7 @@ class TestBaseRepositoryUpdate:
             MockBaseRepository(db_connection=transactional_session).update(schema_object.id, updated_object)
 
     @pytest.mark.freeze_uuids
-    def test_if_only_job_id_changed_then_only_call_update_with_changed_attributes(self, transactional_session):
+    def test_if_only_request_id_changed_then_only_call_update_with_changed_attributes(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
         schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)

--- a/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
@@ -44,8 +44,8 @@ class TestEricaRepositoryCreate:
     @pytest_pgsql.freeze_time(datetime.datetime(2001, 1, 3, 8, 22, 0, tzinfo=datetime.timezone.utc))
     def test_if_create_object_then_set_timestamps_to_now(self, transacted_postgresql_db):
         transacted_postgresql_db.create_table(EricaRequestSchema)
-        job_id = uuid4()
-        mock_object = EricaRequest(request_id=job_id,
+        request_id = uuid4()
+        mock_object = EricaRequest(request_id=request_id,
                                    payload={'endboss': 'Melkor'},
                                    creator_id="api",
                                    type=RequestType.freischalt_code_request,
@@ -53,7 +53,7 @@ class TestEricaRepositoryCreate:
 
         EricaRequestRepository(db_connection=transacted_postgresql_db.session).create(mock_object)
 
-        found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == job_id).first()
+        found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == request_id).first()
 
         assert found_entity.created_at.timestamp() == datetime.datetime.utcnow().timestamp()
         assert found_entity.updated_at.timestamp() == datetime.datetime.utcnow().timestamp()
@@ -63,21 +63,21 @@ class TestEricaRepositoryGetByJobId:
 
     def test_if_entity_in_database_then_return_domain_representation(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
-        job_id = uuid4()
-        mock_object.request_id = job_id
+        request_id = uuid4()
+        mock_object.request_id = request_id
         schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        found_entity = MockEricaRequestRepository(db_connection=transactional_session).get_by_job_id(job_id)
+        found_entity = MockEricaRequestRepository(db_connection=transactional_session).get_by_job_request_id(request_id)
 
         assert found_entity == mock_object
 
     def test_if_entity_not_in_database_then_raise_exception(self, transactional_session):
-        job_id = uuid4()
+        request_id = uuid4()
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequestRepository(db_connection=transactional_session).get_by_job_id(job_id)
+            MockEricaRequestRepository(db_connection=transactional_session).get_by_job_request_id(request_id)
 
 
 class TestEricaRepositoryUpdateByJobId:
@@ -89,7 +89,7 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        updated_entity = MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
+        updated_entity = MockEricaRequestRepository(db_connection=transactional_session).update_by_job_request_id(schema_object.request_id, updated_object)
 
         assert updated_entity == updated_object
 
@@ -100,7 +100,7 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
+        MockEricaRequestRepository(db_connection=transactional_session).update_by_job_request_id(schema_object.request_id, updated_object)
 
         updated_entry_in_db = transactional_session.query(MockSchema).filter(MockSchema.request_id == schema_object.request_id).first()
         assert updated_entry_in_db.request_id == schema_object.request_id
@@ -112,34 +112,34 @@ class TestEricaRepositoryUpdateByJobId:
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
+            MockEricaRequestRepository(db_connection=transactional_session).update_by_job_request_id(schema_object.request_id, updated_object)
 
     def test_if_update_object_then_set_only_updated_at_timestamp(self, transacted_postgresql_db):
         with transacted_postgresql_db.time.freeze('December 31st 1999 11:59:59 PM') as freezer:
             transacted_postgresql_db.create_table(EricaRequestSchema)
-            job_id = uuid4()
-            mock_object = EricaRequest(request_id=job_id,
+            request_id = uuid4()
+            mock_object = EricaRequest(request_id=request_id,
                                        payload={'endboss': 'Melkor'},
                                        creator_id="api",
                                        type=RequestType.freischalt_code_request,
                                        status=Status.new)
             created_object = EricaRequestRepository(db_connection=transacted_postgresql_db.session).create(mock_object)
-            found_entity_before_update = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == job_id).first()
+            found_entity_before_update = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == request_id).first()
             before_update_created_at_timestamp = found_entity_before_update.created_at
             before_update_updated_at_timestamp = found_entity_before_update.updated_at
             created_object.payload = {'endboss': 'Sauron'}
 
             freezer.tick()
 
-            EricaRequestRepository(db_connection=transacted_postgresql_db.session).update_by_job_id(job_id, created_object)
+            EricaRequestRepository(db_connection=transacted_postgresql_db.session).update_by_job_request_id(request_id, created_object)
 
-            found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id==job_id).first()
+            found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id==request_id).first()
 
         assert found_entity.created_at == before_update_created_at_timestamp
         assert found_entity.updated_at > before_update_updated_at_timestamp
 
     @pytest.mark.freeze_uuids
-    def test_if_only_job_id_changed_then_only_call_update_with_changed_attributes(self, transactional_session):
+    def test_if_only_request_id_changed_then_only_call_update_with_changed_attributes(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
         schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)
@@ -150,12 +150,12 @@ class TestEricaRepositoryUpdateByJobId:
         # We need a mock object to be able to intercept the call to the update function
         repo = MockEricaRequestRepository(db_connection=transactional_session)
         update_mock = MagicMock()
-        mocked_get_by_job_id = MagicMock(side_effect=lambda job_id: MagicMock(
-            first=MagicMock(return_value=MockEricaRequestRepository(db_connection=transactional_session)._get_by_job_id(job_id).first()),
+        mocked_get_by_job_request_id = MagicMock(side_effect=lambda request_id: MagicMock(
+            first=MagicMock(return_value=MockEricaRequestRepository(db_connection=transactional_session)._get_by_job_request_id(request_id).first()),
             update=update_mock))
-        repo._get_by_job_id = mocked_get_by_job_id
+        repo._get_by_job_request_id = mocked_get_by_job_request_id
 
-        repo.update_by_job_id(mock_object.request_id, updated_object)
+        repo.update_by_job_request_id(mock_object.request_id, updated_object)
 
         assert update_mock.mock_calls == [call({'request_id': UUID('00000000-0000-0000-0000-000000000000')})]
 
@@ -168,7 +168,7 @@ class TestEricaRepositoryDeleteByJobId:
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.request_id)
+        MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_request_id(schema_object.request_id)
 
         not_found_entry = transactional_session.query(MockSchema).filter(MockSchema.request_id == schema_object.request_id).first()
         assert not_found_entry is None
@@ -178,4 +178,4 @@ class TestEricaRepositoryDeleteByJobId:
         schema_object = MockSchema(**mock_object.dict())
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.request_id)
+            MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_request_id(schema_object.request_id)

--- a/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
@@ -45,7 +45,7 @@ class TestEricaRepositoryCreate:
     def test_if_create_object_then_set_timestamps_to_now(self, transacted_postgresql_db):
         transacted_postgresql_db.create_table(EricaRequestSchema)
         job_id = uuid4()
-        mock_object = EricaRequest(job_id=job_id,
+        mock_object = EricaRequest(request_id=job_id,
                                    payload={'endboss': 'Melkor'},
                                    creator_id="api",
                                    type=RequestType.freischalt_code_request,
@@ -53,7 +53,7 @@ class TestEricaRepositoryCreate:
 
         EricaRequestRepository(db_connection=transacted_postgresql_db.session).create(mock_object)
 
-        found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id == job_id).first()
+        found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == job_id).first()
 
         assert found_entity.created_at.timestamp() == datetime.datetime.utcnow().timestamp()
         assert found_entity.updated_at.timestamp() == datetime.datetime.utcnow().timestamp()
@@ -64,7 +64,7 @@ class TestEricaRepositoryGetByJobId:
     def test_if_entity_in_database_then_return_domain_representation(self, transactional_session):
         mock_object = MockDomainModel(payload={'endboss': 'Melkor'})
         job_id = uuid4()
-        mock_object.job_id = job_id
+        mock_object.request_id = job_id
         schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)
         transactional_session.commit()
@@ -89,7 +89,7 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        updated_entity = MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+        updated_entity = MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
 
         assert updated_entity == updated_object
 
@@ -100,10 +100,10 @@ class TestEricaRepositoryUpdateByJobId:
         transactional_session.commit()
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
-        MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+        MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
 
-        updated_entry_in_db = transactional_session.query(MockSchema).filter(MockSchema.job_id == schema_object.job_id).first()
-        assert updated_entry_in_db.job_id == schema_object.job_id
+        updated_entry_in_db = transactional_session.query(MockSchema).filter(MockSchema.request_id == schema_object.request_id).first()
+        assert updated_entry_in_db.request_id == schema_object.request_id
         assert updated_entry_in_db.payload == {'endboss': 'Sauron'}
 
     def test_if_entity_not_in_database_then_raise_error(self, transactional_session):
@@ -112,19 +112,19 @@ class TestEricaRepositoryUpdateByJobId:
         updated_object = MockDomainModel(payload={'endboss': 'Sauron'})
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.job_id, updated_object)
+            MockEricaRequestRepository(db_connection=transactional_session).update_by_job_id(schema_object.request_id, updated_object)
 
     def test_if_update_object_then_set_only_updated_at_timestamp(self, transacted_postgresql_db):
         with transacted_postgresql_db.time.freeze('December 31st 1999 11:59:59 PM') as freezer:
             transacted_postgresql_db.create_table(EricaRequestSchema)
             job_id = uuid4()
-            mock_object = EricaRequest(job_id=job_id,
+            mock_object = EricaRequest(request_id=job_id,
                                        payload={'endboss': 'Melkor'},
                                        creator_id="api",
                                        type=RequestType.freischalt_code_request,
                                        status=Status.new)
             created_object = EricaRequestRepository(db_connection=transacted_postgresql_db.session).create(mock_object)
-            found_entity_before_update = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id == job_id).first()
+            found_entity_before_update = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id == job_id).first()
             before_update_created_at_timestamp = found_entity_before_update.created_at
             before_update_updated_at_timestamp = found_entity_before_update.updated_at
             created_object.payload = {'endboss': 'Sauron'}
@@ -133,7 +133,7 @@ class TestEricaRepositoryUpdateByJobId:
 
             EricaRequestRepository(db_connection=transacted_postgresql_db.session).update_by_job_id(job_id, created_object)
 
-            found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.job_id==job_id).first()
+            found_entity = transacted_postgresql_db.session.query(EricaRequestSchema).filter(EricaRequestSchema.request_id==job_id).first()
 
         assert found_entity.created_at == before_update_created_at_timestamp
         assert found_entity.updated_at > before_update_updated_at_timestamp
@@ -144,7 +144,7 @@ class TestEricaRepositoryUpdateByJobId:
         schema_object = MockSchema(**mock_object.dict())
         transactional_session.add(schema_object)
         transactional_session.commit()
-        updated_object = MockDomainModel(job_id=uuid4(),
+        updated_object = MockDomainModel(request_id=uuid4(),
                                          payload={'endboss': 'Melkor'})
 
         # We need a mock object to be able to intercept the call to the update function
@@ -155,9 +155,9 @@ class TestEricaRepositoryUpdateByJobId:
             update=update_mock))
         repo._get_by_job_id = mocked_get_by_job_id
 
-        repo.update_by_job_id(mock_object.job_id, updated_object)
+        repo.update_by_job_id(mock_object.request_id, updated_object)
 
-        assert update_mock.mock_calls == [call({'job_id': UUID('00000000-0000-0000-0000-000000000000')})]
+        assert update_mock.mock_calls == [call({'request_id': UUID('00000000-0000-0000-0000-000000000000')})]
 
 
 class TestEricaRepositoryDeleteByJobId:
@@ -168,9 +168,9 @@ class TestEricaRepositoryDeleteByJobId:
         transactional_session.add(schema_object)
         transactional_session.commit()
 
-        MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)
+        MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.request_id)
 
-        not_found_entry = transactional_session.query(MockSchema).filter(MockSchema.job_id == schema_object.job_id).first()
+        not_found_entry = transactional_session.query(MockSchema).filter(MockSchema.request_id == schema_object.request_id).first()
         assert not_found_entry is None
 
     def test_if_entity_not_in_database_then_raise_error(self, transactional_session):
@@ -178,4 +178,4 @@ class TestEricaRepositoryDeleteByJobId:
         schema_object = MockSchema(**mock_object.dict())
 
         with pytest.raises(EntityNotFoundError):
-            MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.job_id)
+            MockEricaRequestRepository(db_connection=transactional_session).delete_by_job_id(schema_object.request_id)


### PR DESCRIPTION
# Short Description
For the EricaRequest we had one column named `job_id`. This was used to reference the request & was then also added as the actual job_id of the job that used that request entity to be run. 
This already lead to some miscommunication and misunderstanding.  Therefore, this column is now renamed to `request_id`. This can be used to reference a request from outside of Erica. Furthermore, the job_id is no longer set explicitly as we do not need to reference the job from the request entity.

# Changes
- Rename column
- Rename all methods and attributes that are related to the request_id
- No longer set the job_id of the job explicitly
- Set the request_id as the parameter for the job

# Feedback
- No tests failed so far. However, we did not reference the entity correctly in the job (we set the entity.id but then used the get_by_job_id). Do you think, we should add additional tests for that?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
