### PR TITLE
Use url to connect with redis

### DIFF
--- a/erica/erica_legacy/config.py
+++ b/erica/erica_legacy/config.py
@@ -26,8 +26,7 @@ class Settings(BaseSettings):
     testing_email_address: str = 'steuerlotse_testing@4germany.org'  # always set, but not evaluated at Elster's
     elster_datenlieferant: str = Field("PLACEHOLDER_DATENLIEFERANT", env='ELSTER_DATENLIEFERANT')
     hersteller_id: str = Field("74931", env='ELSTER_HERSTELLER_ID')
-    queue_host: str = Field("localhost", env='QUEUE_HOST')
-    queue_port: int = Field(6379, env='QUEUE_PORT')
+    queue_url: str = Field("redis://default@localhost:6379/0", env='QUEUE_URL')
     default_queues: List[str] = ['dongle', 'cert', 'common']
     database_url: str = Field("postgresql://postgres:postgres@localhost/db", env="ERICA_DATABASE_URL")
 

--- a/erica/infrastructure/rq/queue.py
+++ b/erica/infrastructure/rq/queue.py
@@ -13,5 +13,5 @@ class QueueNotAvailableError(Exception):
 def get_queue(queue_name='dongle'):
     if queue_name not in _ALLOWED_QUEUE_NAMES:
         raise QueueNotAvailableError
-    with Connection(Redis(get_settings().queue_host, get_settings().queue_port)):
+    with Connection(Redis.from_url(get_settings().queue_url)):
         return Queue(queue_name)

--- a/erica/infrastructure/rq/worker.py
+++ b/erica/infrastructure/rq/worker.py
@@ -7,7 +7,7 @@ from erica.erica_legacy.config import get_settings
 
 
 def run_worker():
-    with Connection(Redis(get_settings().queue_host, get_settings().queue_port)):
+    with Connection(Redis.from_url(get_settings().queue_url)):
         qs = map(Queue, sys.argv[1:]) or [Queue(get_settings().default_queues)]
         worker = Worker(qs)
         worker.work(with_scheduler=True)

--- a/tests/infrastructure/rq/test_queue.py
+++ b/tests/infrastructure/rq/test_queue.py
@@ -13,7 +13,7 @@ class TestQueue:
             get_queue("NOT_ALLOWED_NAME")
 
     def test_if_no_queue_name_then_return_dongle_queue_with_correct_connection(self):
-        expected_queue = Queue("dongle", connection=Redis(get_settings().queue_host, get_settings().queue_port))
+        expected_queue = Queue("dongle", connection=Redis.from_url(get_settings().queue_url))
 
         returned_queue = get_queue()
 
@@ -21,21 +21,21 @@ class TestQueue:
 
 
     def test_if_queue_name_dongle_allowed_then_return_dongle_queue_with_correct_connection(self):
-        expected_queue = Queue("dongle", connection=Redis(get_settings().queue_host, get_settings().queue_port))
+        expected_queue = Queue("dongle", connection=Redis.from_url(get_settings().queue_url))
 
         returned_queue = get_queue("dongle")
 
         assert returned_queue == expected_queue
 
     def test_if_queue_name_cert_allowed_then_return_cert_queue_with_correct_connection(self):
-        expected_queue = Queue("cert", connection=Redis(get_settings().queue_host, get_settings().queue_port))
+        expected_queue = Queue("cert", connection=Redis.from_url(get_settings().queue_url))
 
         returned_queue = get_queue("cert")
 
         assert returned_queue == expected_queue
 
     def test_if_queue_name_common_allowed_then_return_common_queue_with_correct_connection(self):
-        expected_queue = Queue("common", connection=Redis(get_settings().queue_host, get_settings().queue_port))
+        expected_queue = Queue("common", connection=Redis.from_url(get_settings().queue_url))
 
         returned_queue = get_queue("common")
 


### PR DESCRIPTION
# Short Description
For the connection to the redis in our running system we need a password. We can have all the information about the connection to the queue in the url. Therefore, this connects to the url using a url, that can be set through an env variable.

# Changes
- Change config
- Change connection for worker
- Change connection for queue generation

# Feedback
- something I missed?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
