### PR TITLE
NO_TICKET | decode pdf | Update tests

### DIFF
--- a/erica/erica_legacy/request_processing/requests_controller.py
+++ b/erica/erica_legacy/request_processing/requests_controller.py
@@ -131,7 +131,7 @@ class EstRequestController(EstValidationRequestController):
 
     def generate_json(self, pyeric_response: PyericResponse):
         response = super().generate_json(pyeric_response)
-        response['pdf'] = base64.b64encode(pyeric_response.pdf)
+        response['pdf'] = (base64.b64encode(pyeric_response.pdf)).decode('utf-8')
         return response
 
 

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 from datetime import date
 from unittest.mock import patch, MagicMock, call
@@ -194,7 +195,8 @@ class TestEstRequestGenerateJson(unittest.TestCase):
 
     def setUp(self):
         self.expected_transfer_ticket = 'J-KLAPAUCIUS'
-        self.expected_pdf = b"Our lives begin the day we become silent about things that matter"
+        self.pdf_bytes = b"Our lives begin the day we become silent about things that matter"
+        self.expected_pdf = base64.b64encode(self.pdf_bytes).decode('utf-8')
         self.expected_eric_response = "We are now faced with the fact that tomorrow is today."
         with open('tests/erica_legacy/samples/sample_est_response_server.xml') as response_file:
             response_with_correct_transfer_ticket = replace_text_in_xml(response_file.read(),
@@ -211,10 +213,8 @@ class TestEstRequestGenerateJson(unittest.TestCase):
         est_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=True)
         pyeric_response = PyericResponse(self.expected_eric_response,
                                          self.expected_server_response,
-                                         self.expected_pdf)
-        with patch('erica.erica_legacy.request_processing.requests_controller.base64.b64encode',
-                   MagicMock(side_effect=lambda x: x)):
-            actual_response = est_request.generate_json(pyeric_response)
+                                         self.pdf_bytes)
+        actual_response = est_request.generate_json(pyeric_response)
 
         self.assertEqual(expected_output, actual_response)
 
@@ -225,10 +225,9 @@ class TestEstRequestGenerateJson(unittest.TestCase):
         }
         est_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=False)
         pyeric_response = PyericResponse(self.expected_eric_response, self.expected_server_response,
-                                         self.expected_pdf)
-        with patch('erica.erica_legacy.request_processing.requests_controller.base64.b64encode',
-                   MagicMock(side_effect=lambda x: x)):
-            actual_response = est_request.generate_json(pyeric_response)
+                                         self.pdf_bytes)
+
+        actual_response = est_request.generate_json(pyeric_response)
 
         self.assertEqual(expected_output, actual_response)
 


### PR DESCRIPTION
# Short Description
- PDF is now decoded so it can also be saved under the JSONB column of the postgres for v2

# Changes
- Decoding the pdf
- Tests of v2 updated

# Feedback
- Julian will run the integration tests for v2 locally

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
