### PR TITLE
NO_TICKET | Removed global custom handler RequestValidationError

### DIFF
--- a/erica/api/v2/responses/model.py
+++ b/erica/api/v2/responses/model.py
@@ -8,21 +8,16 @@ from erica.application.tax_number_validation.check_tax_number_dto import TaxResp
 model_404_error_get_from_queue = {"model": ResponseErrorDto,
                                   "description": "The requested entity is not present in the database."}
 
-model_422_validation_error_queue = {"model": ResponseErrorDto,
-                                  "description": "The request input payload is not valid."}
-
 model_500_error_get_from_queue = {"model": ResponseErrorDto,
                                   "description": "Unexpected internal server error."}
 
 base_response_get_from_queue = {
     404: model_404_error_get_from_queue,
-    422: model_422_validation_error_queue,
     500: model_500_error_get_from_queue
 }
 
 response_model_post_to_queue = {
     201: {"description": "Job was successfully submitted to the queue and the request id was returned."},
-    422: model_422_validation_error_queue,
     500: model_500_error_get_from_queue}
 
 response_model_get_send_est_from_queue = {


### PR DESCRIPTION
# Short Description
- The contract tests for v1 are failing because with the error handling we introduced a custom handler for RequestValidationError, which was needed because otherwise those errors would be catch with the interval_server_error handler (where we are catching all errors)
- For v2 was it ok because it is the new API
- For v1 it was no ok because that API is still relying on the default handler from FastAPI

# Changes
- Removed custom handler for RequestValidationError and added default FastAPI handler.

# Feedback
- Do we need the errorCode/errorMessage response format for v2 in case of a RequestValidationError? In that case we need to specify an specific custom handler only for v2.
- Actually we had already the default handler also for v2 but I had to introduce a custom one because otherwise the RequestValidationError would be catch with our global interval_server_error handler.
- I think it should be fine if we just do it as I proposed, meaning using a custom handler that uses the default FastAPI handler.

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
