### PR TITLE
Add validation problems

### DIFF
--- a/erica/application/FreischaltCode/FreischaltCodeService.py
+++ b/erica/application/FreischaltCode/FreischaltCodeService.py
@@ -44,7 +44,7 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
             result = ResultFreischaltcodeRequestAndActivationDto(
                 elster_request_id=erica_request.result["elster_request_id"],
                 transfer_ticket=erica_request.result["transfer_ticket"],
-                idnr=erica_request.payload.get("idnr"))
+                idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRequestAndActivationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)
         elif process_status == JobState.FAILURE:
@@ -61,7 +61,7 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
         if process_status == JobState.SUCCESS:
             result = TransferTicketAndIdnrResponseDto(
                 transfer_ticket=erica_request.result["transfer_ticket"],
-                idnr=erica_request.payload.get("idnr"))
+                idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRevocationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)
         elif process_status == JobState.FAILURE:

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -46,8 +46,8 @@ async def perform_job(request_id: UUID, repository: base_repository_interface, s
                 f"Job failed: {entity}. Got Error Message: {e.generate_error_response(True).__str__()}",
                 exc_info=True
             )
-            entity.error_code = e.generate_error_response().get('code')
-            entity.error_message = e.generate_error_response().get('message')
+            entity.error_code = e.generate_error_response().get('message')
+            entity.error_message = e.generate_error_response().get('validation_problems', e.generate_error_response().get('message'))
             entity.status = Status.failed
             repository.update(entity.id, entity)
             raise

--- a/erica/erica_legacy/pyeric/eric_errors.py
+++ b/erica/erica_legacy/pyeric/eric_errors.py
@@ -278,7 +278,7 @@ class EricProcessNotSuccessful(Exception):
 
     @staticmethod
     def get_eric_error_code_message(res_code):
-        return _ERIC_ERROR_MESSAGES.get(res_code, "Unknown error message")
+        return _ERIC_ERROR_MESSAGES.get(res_code, "UNKNOWN_ERROR")
 
     def generate_error_response(self, include_responses=False):
         """

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -63,11 +63,11 @@ async def test_if_post_job_returns_location_with_uuid(api_method, input_data, re
                          ids=["request_fsc", "activate_fsc"])
 async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_result(api_method, request_type):
     request_id = uuid.uuid4()
-    idnr = "test_idnr"
+    tax_id_number = "test_idnr"
     elster_request_id = "test_elster_request_id"
     transfer_ticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=request_type, status=Status.success,
-                                 payload={"idnr": idnr},
+                                 payload={"tax_id_number": tax_id_number},
                                  result={"elster_request_id": elster_request_id,
                                          "transfer_ticket": transfer_ticket},
                                  request_id=request_id, creator_id="test")
@@ -76,7 +76,7 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
         get_service_mock.return_value = FreischaltCodeService(service=mock_service)
         response = await api_method(request_id)
         assert response.processStatus == JobState.SUCCESS
-        assert response.result.idnr == idnr
+        assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
         assert response.result.transfer_ticket == transfer_ticket
         assert response.errorCode is None
@@ -86,18 +86,18 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
 @pytest.mark.asyncio
 async def test_if_get_fsc_revocation_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
-    idnr = "test_idnr"
+    tax_id_number = "test_idnr"
     transfer_ticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
-                                 payload={"idnr": idnr},
-                                 result={"transfer_ticket": transfer_ticket, "idnr": idnr},
+                                 payload={"tax_id_number": tax_id_number},
+                                 result={"transfer_ticket": transfer_ticket, "idnr": tax_id_number},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.fsc.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
         get_service_mock.return_value = FreischaltCodeService(service=mock_service)
         response = await get_fsc_revocation_job(request_id)
         assert response.processStatus == JobState.SUCCESS
-        assert response.result.idnr == idnr
+        assert response.result.idnr == tax_id_number
         assert response.result.transfer_ticket == transfer_ticket
         assert response.errorCode is None
         assert response.errorMessage is None

--- a/tests/application/FreischaltCode/test_freischaltcode_service.py
+++ b/tests/application/FreischaltCode/test_freischaltcode_service.py
@@ -106,11 +106,11 @@ class TestFreischaltCodeService:
         assert response.result is None
 
     def test_fsc_request_if_erica_request_found_and_success_then_return_success_response_dto(self):
-        idnr = "test_idnr"
+        tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
         transfer_ticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_request, status=Status.success,
-                                     payload={"idnr": idnr},
+                                     payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
                                              "transfer_ticket": transfer_ticket},
                                      request_id=uuid.uuid4(),
@@ -119,18 +119,18 @@ class TestFreischaltCodeService:
         mock_service = MagicMock(get_request_by_request_id=mock_get_request_by_request_id)
         response = FreischaltCodeService(service=mock_service).get_response_freischaltcode_request("test")
         assert response.processStatus == JobState.SUCCESS
-        assert response.result.idnr == idnr
+        assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
         assert response.result.transfer_ticket == transfer_ticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
     def test_fsc_activate_if_erica_request_found_and_success_then_return_success_response_dto(self):
-        idnr = "test_idnr"
+        tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
         transfer_ticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_activate, status=Status.success,
-                                     payload={"idnr": idnr},
+                                     payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
                                              "transfer_ticket": transfer_ticket},
                                      request_id=uuid.uuid4(),
@@ -139,25 +139,25 @@ class TestFreischaltCodeService:
         mock_service = MagicMock(get_request_by_request_id=mock_get_request_by_request_id)
         response = FreischaltCodeService(service=mock_service).get_response_freischaltcode_activation("test")
         assert response.processStatus == JobState.SUCCESS
-        assert response.result.idnr == idnr
+        assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
         assert response.result.transfer_ticket == transfer_ticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
     def test_fsc_revocate_if_erica_request_found_and_success_then_return_success_response_dto(self):
-        idnr = "test_idnr"
+        tax_id_number = "test_idnr"
         transfer_ticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
-                                     payload={"idnr": idnr},
-                                     result={"transfer_ticket": transfer_ticket, "idnr": idnr},
+                                     payload={"tax_id_number": tax_id_number},
+                                     result={"transfer_ticket": transfer_ticket, "idnr": tax_id_number},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
         mock_service = MagicMock(get_request_by_request_id=mock_get_request_by_request_id)
         response = FreischaltCodeService(service=mock_service).get_response_freischaltcode_revocation("test")
         assert response.processStatus == JobState.SUCCESS
-        assert response.result.idnr == idnr
+        assert response.result.idnr == tax_id_number
         assert response.result.transfer_ticket == transfer_ticket
         assert response.errorCode is None
         assert response.errorMessage is None

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 
 from erica.application.JobService.job import perform_job
 from erica.domain.Shared.Status import Status
-from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful
+from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful, EricGlobalValidationError
 from erica.infrastructure.sqlalchemy.repositories.base_repository import EntityNotFoundError
 
 
@@ -37,18 +37,39 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_service_raises_error_then_update_entity_in_database_with_correct_values(self):
+        validation_problems = "These are not the Ericas you are looking for"
         mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
         mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
         mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
-        mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricProcessNotSuccessful))
+        mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricGlobalValidationError(
+            eric_response=f"<xml><Text>{validation_problems}</Text></xml>".encode())))
 
         with pytest.raises(EricProcessNotSuccessful):
             await perform_job(request_id=uuid4(), repository=mock_repository, service=mock_service,
                               payload_type=MagicMock(), logger=MagicMock())
 
-        assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('code')
-        assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
+        assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('message')
+        assert mock_entity.error_message == [validation_problems]
+        assert mock_entity.status == Status.failed
+        assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
+
+    @pytest.mark.asyncio
+    async def test_if_service_raises_error_with_validation_problems_then_update_entity_in_database_with_correct_values(self):
+        validation_problems = "These are not the Ericas you are looking for"
+        mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
+        mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
+        mock_update = MagicMock()
+        mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
+        mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricGlobalValidationError(
+            eric_response=f"<xml><Text>{validation_problems}</Text></xml>".encode())))
+
+        with pytest.raises(EricProcessNotSuccessful):
+            await perform_job(request_id=uuid4(), repository=mock_repository, service=mock_service,
+                              payload_type=MagicMock(), logger=MagicMock())
+
+        assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('message')
+        assert mock_entity.error_message == [validation_problems]
         assert mock_entity.status == Status.failed
         assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
 


### PR DESCRIPTION
# Short Description
While working on grundsteuer I realized that we do not add the correct errors for validation problems instead we set the error code (a number not a string) and then the error message is just the short descriptor of the error. This changes that. We probably should change the error messages in errors.py in the future

# Changes
- Add validation problems to Global Prüffehler answers
- Fix a small problem where we still did use idnr instead of tax_id_number

# Feedback
- Does this make sense to you?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
