### PR TITLE
STL-2050 | Fix cron jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod -x /etc/cron.d/*
 
 COPY . .
 
-# Get tax office list and ERiC librariescd
+# Get tax office list and ERiC libraries
 RUN env ERICA_BUCKET_NAME=$bucket_name AWS_ACCESS_KEY_ID=$access_key_id AWS_SECRET_ACCESS_KEY=$access_key ENDPOINT_URL=$endpoint_url pipenv run python scripts/load_eric_binaries.py download-eric-cert-and-binaries
 RUN env ERICA_ENV=testing pipenv run python scripts/create_tax_office_lists.py create
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,17 +24,20 @@ RUN ln -sf /proc/1/fd/1 /app/cronjob_not_finished_output
 #  apt-get install -y vim telnet coreutils less strace lsof rsyslog usbutils && \
 #  rm -rf /var/lib/apt/lists/\*
 
+COPY ./entrypoint.sh /entrypoint.sh
+
 RUN pip install --upgrade pip pipenv
 COPY ./Pipfile ./Pipfile.lock ./
 RUN pipenv install
 
 COPY ./erica/cron.d/* /etc/cron.d/
-
-COPY ./entrypoint.sh /entrypoint.sh
+RUN chown root:root /etc/cron.d/*
+RUN chmod go-wx /etc/cron.d/*
+RUN chmod -x /etc/cron.d/*
 
 COPY . .
 
-# Get tax office list and ERiC libraries
+# Get tax office list and ERiC librariescd
 RUN env ERICA_BUCKET_NAME=$bucket_name AWS_ACCESS_KEY_ID=$access_key_id AWS_SECRET_ACCESS_KEY=$access_key ENDPOINT_URL=$endpoint_url pipenv run python scripts/load_eric_binaries.py download-eric-cert-and-binaries
 RUN env ERICA_ENV=testing pipenv run python scripts/create_tax_office_lists.py create
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -ex
 
+# Set environment variables for cron job (loaded automatically by python-dotenv)
+rm -f /app/.env
+touch /app/.env
+set +x  # Turn off command logging to avoid leaking secrets
+echo "PYTHONDONTWRITEBYTECODE=$PYTHONDONTWRITEBYTECODE" >> /app/.env
+echo "PYTHONUNBUFFERED=$PYTHONUNBUFFERED" >> /app/.env
+echo "ERICA_ENV=$ERICA_ENV" >> /app/.env
+echo "DONGLE_CONNECTED=$DONGLE_CONNECTED" >> /app/.env
+echo "ERICA_DATABASE_URL=$ERICA_DATABASE_URL" >> /app/.env
+set -x  # Turn command logging back on
+
 service pcscd start
 
 if [[ $RUN_WITH_WORKER == "True" ]]

--- a/erica/cron.d/delete_success_fail_and_update_not_finished
+++ b/erica/cron.d/delete_success_fail_and_update_not_finished
@@ -1,3 +1,0 @@
-SHELL=/bin/bash
-*/5 * * * * root cd /erica && /usr/local/bin/env ERICA_ENV=development pipenv run python erica/infrastructure/sqlalchemy/cron/jobs.py delete-success-fail-entities &> /app/cronjob_success_fail_output
-*/5 * * * * root cd /erica && /usr/local/bin/env ERICA_ENV=development pipenv run python erica/infrastructure/sqlalchemy/cron/jobs.py update-status-not-finished-entities &> /app/cronjob_not_finished_output

--- a/erica/cron.d/delete_success_fail_entities
+++ b/erica/cron.d/delete_success_fail_entities
@@ -1,0 +1,2 @@
+SHELL=/bin/bash
+*/5 * * * * root cd /app && /usr/local/bin/pipenv run python erica/infrastructure/sqlalchemy/cron/update_entities_utils.py delete-success-fail-entities &> /app/cronjob_success_fail_output

--- a/erica/cron.d/set_not_processed_entities_to_failed
+++ b/erica/cron.d/set_not_processed_entities_to_failed
@@ -1,0 +1,2 @@
+SHELL=/bin/bash
+*/5 * * * * root cd /app && /usr/local/bin/pipenv run python erica/infrastructure/sqlalchemy/cron/update_entities_utils.py set-not-processed-entities-to-failed &> /app/cronjob_not_processed_output

--- a/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
+++ b/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
@@ -21,20 +21,18 @@ def delete_success_fail_entities():
     eric_request_repo = injector.inject(EricaRequestRepository)
     entities_deleted = eric_request_repo.delete_success_fail_old_entities(
         get_settings().ttl_finished_request_entities_in_min)
-    logging.getLogger().debug(
-        str(entities_deleted) + " success/fail entities deleted at " + datetime.now().strftime("%H:%M:%S"),
-        exc_info=True)
+    logging.getLogger().info(
+        str(entities_deleted) + " success/fail entities deleted at " + datetime.now().strftime("%H:%M:%S"))
 
 
 @cli.command()
-def update_status_not_finished_entities():
+def set_not_processed_entities_to_failed():
     injector = Injector([InfrastructureModule()])
     erica_request_repo = injector.inject(EricaRequestRepository)
-    entities_updated = erica_request_repo.update_status_not_finished_entities_to_failed(
+    entities_updated = erica_request_repo.set_not_processed_entities_to_failed(
         get_settings().ttl_processing_request_entities_in_min)
-    logging.getLogger().debug(
-        str(entities_updated) + " processing entities  set to failedat " + datetime.now().strftime("%H:%M:%S"),
-        exc_info=True)
+    logging.getLogger().info(
+        str(entities_updated) + " processing entities  set to failedat " + datetime.now().strftime("%H:%M:%S"))
 
 
 if __name__ == "__main__":

--- a/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
+++ b/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
@@ -21,7 +21,7 @@ def delete_success_fail_entities():
     eric_request_repo = injector.inject(EricaRequestRepository)
     entities_deleted = eric_request_repo.delete_success_fail_old_entities(
         get_settings().ttl_finished_request_entities_in_min)
-    logging.getLogger().info(
+    logging.getLogger().debug(
         str(entities_deleted) + " success/fail entities deleted at " + datetime.now().strftime("%H:%M:%S"))
 
 
@@ -31,7 +31,7 @@ def set_not_processed_entities_to_failed():
     erica_request_repo = injector.inject(EricaRequestRepository)
     entities_updated = erica_request_repo.set_not_processed_entities_to_failed(
         get_settings().ttl_processing_request_entities_in_min)
-    logging.getLogger().info(
+    logging.getLogger().debug(
         str(entities_updated) + " processing entities  set to failedat " + datetime.now().strftime("%H:%M:%S"))
 
 

--- a/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
+++ b/erica/infrastructure/sqlalchemy/repositories/erica_request_repository.py
@@ -62,7 +62,7 @@ class EricaRequestRepository(
         self.db_connection.commit()
         return deleted.rowcount
 
-    def update_status_not_finished_entities_to_failed(self, ttl) -> int:
+    def set_not_processed_entities_to_failed(self, ttl) -> int:
         stmt = self.DatabaseEntity.__table__.update() \
             .where(or_(self.DatabaseEntity.status == Status.new, self.DatabaseEntity.status == Status.scheduled,
                        self.DatabaseEntity.status == Status.processing),

--- a/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
+++ b/tests/infrastructure/sqlalechemy/repositories/test_erica_request_repository.py
@@ -257,7 +257,7 @@ class TestEricaRepositoryUpdateProcessing:
         EricaRequestRepository(db_connection=transactional_erica_postgresql_db.session).create(mock_object)
 
         updated = EricaRequestRepository(
-            db_connection=transactional_erica_postgresql_db.session).update_status_not_finished_entities_to_failed(1)
+            db_connection=transactional_erica_postgresql_db.session).set_not_processed_entities_to_failed(1)
         assert updated == 1
         entity_found = transactional_erica_postgresql_db.session.query(EricaRequestSchema).filter(
             EricaRequestSchema.request_id == request_id).first()
@@ -279,7 +279,7 @@ class TestEricaRepositoryUpdateProcessing:
         EricaRequestRepository(db_connection=transactional_erica_postgresql_db.session).create(mock_object)
 
         updated = EricaRequestRepository(
-            db_connection=transactional_erica_postgresql_db.session).update_status_not_finished_entities_to_failed(1)
+            db_connection=transactional_erica_postgresql_db.session).set_not_processed_entities_to_failed(1)
         assert updated == 0
         entity_found = transactional_erica_postgresql_db.session.query(EricaRequestSchema).filter(
             EricaRequestSchema.request_id == request_id).first()


### PR DESCRIPTION
# Short Description
- Finally the cron jobs for the erica should run

# Changes
- Separated cron jobs, before they were in the same file (what is not possible)
- Corrected cron job definitions
- Added permission magement in the dockerfile for the cron jobs pasted to /etc/cron.d (needed as explained [here](https://unix.stackexchange.com/a/478581))
- Method renamed so that they better match the use case.
- Added env file definition in the entrypoint (needed at least for the ERICA_ENV since it was removed from the cron job definition) and as it is used in the webapp

# Feedback
- I tested them locally and they worked! But should try them also on staging.

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
