### PR TITLE
STL-2159 | Added supervisord and creation of new erica_worker image |…

### DIFF
--- a/contract_tests/test_integration_queue.py
+++ b/contract_tests/test_integration_queue.py
@@ -173,7 +173,7 @@ class TestV2UnlockCodeRequest:
                                  data=json.dumps(full_unlock_code_request_data, default=str))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[3]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
 
         assert response.status_code == 200
@@ -237,7 +237,7 @@ class TestV2UnlockCodeActivation:
                                  data=json.dumps(full_unlock_code_activation_data, default=str))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[3]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
 
         assert response.status_code == 200
@@ -301,7 +301,7 @@ class TestV2UnlockCodeRevocation:
                                  data=json.dumps(full_unlock_code_revocation_data, default=str))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[3]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
 
         assert response.status_code == 200
@@ -363,7 +363,7 @@ class TestV2TaxNumberValidity:
                                  data=json.dumps(tax_number_validity_data, default=str))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[2]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
 
         assert response.status_code == 200
@@ -437,7 +437,7 @@ class TestV2SendEst:
                                  data=json.dumps(full_est_data, default=str))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[2]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
 
         assert response.status_code == 200
@@ -502,7 +502,7 @@ class TestV2GrundsteuerRequest:
                                  data=json.dumps(request, default=json_default))
         assert response.status_code == 201
         uuid = response.headers['Location'].split("/")[2]
-        sleep(10)
+        sleep(5)
         response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
         assert response.status_code == 200
         assert response.json()["processStatus"] == "Failure"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,13 +1,30 @@
 # Note: this docker-compose file is used for building staging/production images on GitHub Actions.
 version: '3.8'
 
-# Define common behavior of web
-x-web:
-  &default-web
+# Define common behavior of api
+x-api:
+  &default-api
   image: erica_api:latest
   build:
     context: .
     target: erica
+    args:
+      bucket_name: ${ERICA_BUCKET_NAME}
+      access_key_id: ${ACCESS_KEY_ID}
+      access_key: ${ACCESS_KEY}
+      endpoint_url: ${ENDPOINT_URL}
+      elster_datenlieferant: ${ELSTER_DATENLIEFERANT}
+      elster_hersteller_id: ${ELSTER_HERSTELLER_ID}
+  expose:
+    - 8000
+
+# Define common behavior of worker
+x-worker:
+  &default-worker
+  image: erica_worker:latest
+  build:
+    context: .
+    target: worker
     args:
       bucket_name: ${ERICA_BUCKET_NAME}
       access_key_id: ${ACCESS_KEY_ID}
@@ -34,14 +51,23 @@ x-cron:
       elster_hersteller_id: ${ELSTER_HERSTELLER_ID}
 
 services:
-  # Web latest
-  web_latest:
-    *default-web
+  # api latest
+  api_latest:
+    *default-api
 
-  # Web github run
-  web_github_run:
-    << : *default-web
+  # api github run
+  api_github_run:
+    << : *default-api
     image: erica_api:${DOCKER_TAG}
+
+  # worker latest
+  worker_latest:
+    *default-worker
+
+  # worker github run
+  worker_github_run:
+    << : *default-worker
+    image: erica_worker:${DOCKER_TAG}
 
   # Cron latest
   cron_latest:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,4 @@ set -x  # Turn command logging back on
 
 service pcscd start
 
-if [[ $RUN_WITH_WORKER == "True" ]]
-then
-  pipenv run python -m erica.infrastructure.rq.worker&
-  exec pipenv run "$@"
-else
-  exec pipenv run "$@"
-fi
+exec pipenv run "$@"

--- a/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
+++ b/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
@@ -1,8 +1,11 @@
 import logging
 import os
 from datetime import datetime
+from logging.config import dictConfig
+
 import click
 import sys
+
 sys.path.append(os.getcwd())
 from erica.config import get_settings
 from erica.infrastructure.sqlalchemy.repositories.erica_request_repository import EricaRequestRepository
@@ -31,9 +34,36 @@ def set_not_processed_entities_to_failed():
     erica_request_repo = injector.inject(EricaRequestRepository)
     entities_updated = erica_request_repo.set_not_processed_entities_to_failed(
         get_settings().ttl_processing_request_entities_in_min)
-    logging.getLogger().debug(
-        str(entities_updated) + " processing entities  set to failedat " + datetime.now().strftime("%H:%M:%S"))
+    log_message = str(
+        entities_updated) + " new/scheduled/processing entities  set to failed at " + datetime.now().strftime(
+        "%H:%M:%S")
+    if entities_updated > 0:
+        logging.getLogger().error(log_message)
+    else:
+        logging.getLogger().debug(log_message)
 
+
+dictConfig({
+    "version": 1,
+    "formatters": {
+        "default": {
+            "format": "%(asctime)s%(levelname)s%(name)s%(message)s%(module)s%(lineno)s%(process)d%(thread)d",
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter"
+        }
+    },
+    "handlers": {
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+            "formatter": "default"
+        }
+    },
+    "root": {
+        "level": logging.INFO,
+        "handlers": ["stderr"]
+    },
+    "disable_existing_loggers": False
+})
 
 if __name__ == "__main__":
     cli()

--- a/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
+++ b/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
@@ -37,13 +37,14 @@ def set_not_processed_entities_to_failed():
     log_message = str(
         entities_updated) + " new/scheduled/processing entities  set to failed at " + datetime.now().strftime(
         "%H:%M:%S")
+    logging.config.dictConfig(LOGGIN_CONFIG)
     if entities_updated > 0:
         logging.getLogger().error(log_message)
     else:
         logging.getLogger().debug(log_message)
 
 
-dictConfig({
+LOGGIN_CONFIG = {
     "version": 1,
     "formatters": {
         "default": {
@@ -63,7 +64,7 @@ dictConfig({
         "handlers": ["stderr"]
     },
     "disable_existing_loggers": False
-})
+}
 
 if __name__ == "__main__":
     cli()

--- a/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
+++ b/erica/infrastructure/sqlalchemy/cron/update_entities_utils.py
@@ -37,14 +37,13 @@ def set_not_processed_entities_to_failed():
     log_message = str(
         entities_updated) + " new/scheduled/processing entities  set to failed at " + datetime.now().strftime(
         "%H:%M:%S")
-    logging.config.dictConfig(LOGGIN_CONFIG)
     if entities_updated > 0:
         logging.getLogger().error(log_message)
     else:
         logging.getLogger().debug(log_message)
 
 
-LOGGIN_CONFIG = {
+dictConfig({
     "version": 1,
     "formatters": {
         "default": {
@@ -64,7 +63,7 @@ LOGGIN_CONFIG = {
         "handlers": ["stderr"]
     },
     "disable_existing_loggers": False
-}
+})
 
 if __name__ == "__main__":
     cli()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,32 @@
+[supervisord]
+# needed to avoid CRIT level log
+user=root
+
+[program:worker]
+command=env ERICA_ENV=%(ENV_ERICA_ENV)s pipenv run python -m erica.infrastructure.rq.worker
+process_name=%(program_name)s-%(process_num)s
+numprocs=5
+directory=/app
+stopsignal=TERM
+autostart=%(ENV_RUN_WITH_WORKER)s
+autorestart=true
+# The following needed for redirecting both stdout and stderr of program (child process) to supervisord
+# maxbytes=0 disabled log rotation, since the default value for is 50MB and supervisord is not smart enough to detect that the specified log file is not a regular file.
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:api]
+command=env ERICA_ENV=%(ENV_ERICA_ENV)s pipenv run python -m erica
+process_name=%(program_name)s-%(process_num)s
+numprocs=1
+directory=/app
+stopsignal=TERM
+autostart=true
+autorestart=true
+# Same as above
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
# Short Description
- Creation of multiple rq worker using supervisord
- Reduction of sleep time of integration tests v2 to 5 seconds

# Changes
- Added creation of new target in Dockerfile because of usage of supervisord for the VM
- supervisord manages now both the 5 workers and the erica api
- entrypoint now simplified since supervisord can conditionally autostart a program (for our case the worker)
- Updated docker-compose.ci for the new image erica_worker and also renamed the previous wrongly named "web" to "api"
- Reorganized the docker file so that packages are only installed in the specific targets whey they are needed (cron or worker images)
- Logs of child processes of supervisord are automatically redirected to the stdout/stderr of supervisor, meaning we have the logs we we had them before (docker logs)

# Feedback
- Something missing? I tested it locally and they are damm fast the 5 workers! Integration tests are almost every time completed with a sleep time of 2 seconds (set them anyway to 5 seconds sleep)
- IMPORTANT: before this PR is merged into main [this infra PR](https://github.com/digitalservice4germany/steuerlotse-infra/pull/48) should be merged first (because of the new image name erica_worker)

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
