### PR TITLE
Use transferticket as one word

### DIFF
--- a/contract_tests/test_integration_queue.py
+++ b/contract_tests/test_integration_queue.py
@@ -603,7 +603,7 @@ class TestV2SendEst:
         assert response.json()["processStatus"] == "Success"
         assert response.json()["result"] is not None
         assert response.json()["result"]["pdf"] is not None
-        assert response.json()["result"]["transfer_ticket"] is not None
+        assert response.json()["result"]["transferticket"] is not None
         assert response.json()["errorCode"] is None
         assert response.json()["errorMessage"] is None
 
@@ -666,6 +666,8 @@ class TestV2GrundsteuerRequest:
         assert response.status_code == 200
         assert response.json()["processStatus"] == "Success"
         assert response.json()["result"] is not None
+        assert response.json()["result"]["pdf"] is not None
+        assert response.json()["result"]["transferticket"] is not None
         assert response.json()["errorCode"] is None
         assert response.json()["errorMessage"] is None
 

--- a/erica/application/EricRequestProcessing/grundsteuer_request_controller.py
+++ b/erica/application/EricRequestProcessing/grundsteuer_request_controller.py
@@ -7,9 +7,9 @@ from erica.erica_legacy.elster_xml.common.transfer_header import add_transfer_he
 from erica.erica_legacy.elster_xml.common.xml_conversion import convert_object_to_xml
 from erica.erica_legacy.elster_xml.grundsteuer.elster_data_representation import get_full_grundsteuer_data_representation
 from erica.erica_legacy.elster_xml.transfer_header_fields import get_grundsteuer_th_fields
-from erica.erica_legacy.request_processing.requests_controller import TransferTicketRequestController
+from erica.erica_legacy.request_processing.requests_controller import TransferticketRequestController
 
-class GrundsteuerRequestController(TransferTicketRequestController):
+class GrundsteuerRequestController(TransferticketRequestController):
     _PYERIC_CONTROLLER = GrundsteuerPyericProcessController
 
     def _is_testmerker_used(self):

--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -41,12 +41,12 @@ class FreischaltCodeRevocateDto(BaseDto):
 
 # Output
 
-class TransferTicketAndIdnrResponseDto(BaseDto):
+class TransferticketAndIdnrResponseDto(BaseDto):
     transferticket: str
     idnr: str
 
 
-class ResultFreischaltcodeRequestAndActivationDto(TransferTicketAndIdnrResponseDto):
+class ResultFreischaltcodeRequestAndActivationDto(TransferticketAndIdnrResponseDto):
     elster_request_id: str
 
 
@@ -55,4 +55,4 @@ class FreischaltcodeRequestAndActivationResponseDto(ResponseBaseDto):
 
 
 class FreischaltcodeRevocationResponseDto(ResponseBaseDto):
-    result: Optional[TransferTicketAndIdnrResponseDto]
+    result: Optional[TransferticketAndIdnrResponseDto]

--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -42,7 +42,7 @@ class FreischaltCodeRevocateDto(BaseDto):
 # Output
 
 class TransferTicketAndIdnrResponseDto(BaseDto):
-    transfer_ticket: str
+    transferticket: str
     idnr: str
 
 

--- a/erica/application/FreischaltCode/FreischaltCodeService.py
+++ b/erica/application/FreischaltCode/FreischaltCodeService.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from opyoid import Module
 
 from erica.application.FreischaltCode.FreischaltCode import FreischaltcodeRequestAndActivationResponseDto, \
-    ResultFreischaltcodeRequestAndActivationDto, FreischaltcodeRevocationResponseDto, TransferTicketAndIdnrResponseDto
+    ResultFreischaltcodeRequestAndActivationDto, FreischaltcodeRevocationResponseDto, TransferticketAndIdnrResponseDto
 from erica.application.Shared.base_service import BaseService
 from erica.application.Shared.response_dto import JobState
 from erica.application.Shared.response_state_mapper import map_status
@@ -43,7 +43,7 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
         if process_status == JobState.SUCCESS:
             result = ResultFreischaltcodeRequestAndActivationDto(
                 elster_request_id=erica_request.result["elster_request_id"],
-                transferticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transferticket"],
                 idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRequestAndActivationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)
@@ -59,8 +59,8 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
         erica_request = self.get_erica_request(request_id, RequestType.freischalt_code_revocate)
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
-            result = TransferTicketAndIdnrResponseDto(
-                transferticket=erica_request.result["transfer_ticket"],
+            result = TransferticketAndIdnrResponseDto(
+                transferticket=erica_request.result["transferticket"],
                 idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRevocationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/application/FreischaltCode/FreischaltCodeService.py
+++ b/erica/application/FreischaltCode/FreischaltCodeService.py
@@ -43,7 +43,7 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
         if process_status == JobState.SUCCESS:
             result = ResultFreischaltcodeRequestAndActivationDto(
                 elster_request_id=erica_request.result["elster_request_id"],
-                transfer_ticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transfer_ticket"],
                 idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRequestAndActivationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)
@@ -60,7 +60,7 @@ class FreischaltCodeService(FreischaltCodeServiceInterface):
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
             result = TransferTicketAndIdnrResponseDto(
-                transfer_ticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transfer_ticket"],
                 idnr=erica_request.payload.get("tax_id_number"))
             return FreischaltcodeRevocationResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/application/Shared/response_dto.py
+++ b/erica/application/Shared/response_dto.py
@@ -23,5 +23,5 @@ class ResponseErrorDto(BaseDto):
 
 
 class ResultTransferPdfResponseDto(BaseDto):
-    transfer_ticket: str
+    transferticket: str
     pdf: str

--- a/erica/application/grundsteuer/GrundsteuerService.py
+++ b/erica/application/grundsteuer/GrundsteuerService.py
@@ -25,7 +25,7 @@ class GrundsteuerService(GrundsteuerServiceInterface):
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
             result = ResultTransferPdfResponseDto(
-                transferticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transferticket"],
                 pdf=erica_request.result["pdf"])
             return GrundsteuerResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/application/grundsteuer/GrundsteuerService.py
+++ b/erica/application/grundsteuer/GrundsteuerService.py
@@ -25,7 +25,7 @@ class GrundsteuerService(GrundsteuerServiceInterface):
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
             result = ResultTransferPdfResponseDto(
-                transfer_ticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transfer_ticket"],
                 pdf=erica_request.result["pdf"])
             return GrundsteuerResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/application/tax_declaration/TaxDeclarationService.py
+++ b/erica/application/tax_declaration/TaxDeclarationService.py
@@ -25,7 +25,7 @@ class TaxDeclarationService(TaxDeclarationServiceInterface):
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
             result = ResultTransferPdfResponseDto(
-                transfer_ticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transfer_ticket"],
                 pdf=erica_request.result["pdf"])
             return EstResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/application/tax_declaration/TaxDeclarationService.py
+++ b/erica/application/tax_declaration/TaxDeclarationService.py
@@ -25,7 +25,7 @@ class TaxDeclarationService(TaxDeclarationServiceInterface):
         process_status = map_status(erica_request.status)
         if process_status == JobState.SUCCESS:
             result = ResultTransferPdfResponseDto(
-                transferticket=erica_request.result["transfer_ticket"],
+                transferticket=erica_request.result["transferticket"],
                 pdf=erica_request.result["pdf"])
             return EstResponseDto(
                 processStatus=map_status(erica_request.status), result=result)

--- a/erica/erica_legacy/api/v1/endpoints/est.py
+++ b/erica/erica_legacy/api/v1/endpoints/est.py
@@ -22,7 +22,10 @@ def validate_est(est: EstData, include_elster_responses: bool = False):
     """
     try:
         request = EstValidationRequestController(est, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not validate est", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))
@@ -43,7 +46,10 @@ def send_est(est: EstData, include_elster_responses: bool = False):
     """
     try:
         request = EstRequestController(est, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not send est", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))

--- a/erica/erica_legacy/api/v1/endpoints/grundsteuer.py
+++ b/erica/erica_legacy/api/v1/endpoints/grundsteuer.py
@@ -13,7 +13,7 @@ router = APIRouter()
 def send_grundsteuer(grundsteuer: GrundsteuerPayload, include_elster_responses: bool = False):
     """
     The Grundsteuer data is validated and then send to ELSTER using ERiC. If it is successful, this should return a 201
-    HTTP response with {'transfer_ticket': str, 'pdf': str}. The pdf is base64 encoded binary data of the pdf
+    HTTP response with {'transferticket': str, 'pdf': str}. The pdf is base64 encoded binary data of the pdf
     If there is any error with the validation, this should return a 400 response. If the validation failed with
     {‘code’ : int,‘message’: str,‘description’: str, ‘validation_problems’ : [{‘code’: int, ‘message’: str}]}
     or a 400 repsonse for other client errors and a 500 response for server errors with
@@ -24,7 +24,10 @@ def send_grundsteuer(grundsteuer: GrundsteuerPayload, include_elster_responses: 
     """
     try:
         request = GrundsteuerRequestController(grundsteuer, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not send grundsteuer", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))

--- a/erica/erica_legacy/api/v1/endpoints/unlock_code.py
+++ b/erica/erica_legacy/api/v1/endpoints/unlock_code.py
@@ -22,7 +22,10 @@ def request_unlock_code(unlock_code_request: UnlockCodeRequestData, include_elst
     """
     try:
         request = UnlockCodeRequestController(unlock_code_request, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not request unlock code", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))
@@ -40,7 +43,10 @@ def activate_unlock_code(unlock_code_activation: UnlockCodeActivationData, inclu
     """
     try:
         request = UnlockCodeActivationRequestController(unlock_code_activation, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not activate unlock code", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))
@@ -59,7 +65,10 @@ def revoke_unlock_code(unlock_code_revocation: UnlockCodeRevocationData, include
     """
     try:
         request = UnlockCodeRevocationRequestController(unlock_code_revocation, include_elster_responses)
-        return request.process()
+        result = request.process()
+        if "transferticket" in result:
+            result["transfer_ticket"] = result.pop("transferticket")
+        return result
     except EricProcessNotSuccessful as e:
         logging.getLogger().info("Could not revoke unlock code", exc_info=True)
         raise HTTPException(status_code=422, detail=e.generate_error_response(include_elster_responses))

--- a/erica/erica_legacy/elster_xml/xml_parsing/elster_specifics_xml_parsing.py
+++ b/erica/erica_legacy/elster_xml/xml_parsing/elster_specifics_xml_parsing.py
@@ -34,7 +34,7 @@ def get_idnr_from_xml(xml_string):
     return _get_element_from_xml(xml_string, 'DateninhaberIdNr')
 
 
-def get_transfer_ticket_from_xml(xml_string):
+def get_transferticket_from_xml(xml_string):
     return _get_element_from_xml(xml_string, 'TransferTicket')
 
 

--- a/erica/erica_legacy/request_processing/requests_controller.py
+++ b/erica/erica_legacy/request_processing/requests_controller.py
@@ -5,7 +5,7 @@ from erica.erica_legacy.elster_xml.common.electronic_steuernummer import generat
 from erica.erica_legacy.elster_xml.elster_xml_generator import get_belege_xml, generate_vorsatz_without_tax_number, \
     generate_vorsatz_with_tax_number
 from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_antrag_id_from_xml, \
-    get_transfer_ticket_from_xml, get_address_from_xml, get_relevant_beleg_ids
+    get_transferticket_from_xml, get_address_from_xml, get_relevant_beleg_ids
 from erica.erica_legacy.pyeric.eric_errors import InvalidBufaNumberError
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from erica.erica_legacy.elster_xml import est_mapping, elster_xml_generator
@@ -71,16 +71,16 @@ class EricaRequestController(object):
         return response
 
 
-class TransferTicketRequestController(EricaRequestController):
+class TransferticketRequestController(EricaRequestController):
 
     def generate_json(self, pyeric_response: PyericResponse):
         response = super().generate_json(pyeric_response)
         if pyeric_response.server_response:
-            response['transfer_ticket'] = get_transfer_ticket_from_xml(pyeric_response.server_response)
+            response['transferticket'] = get_transferticket_from_xml(pyeric_response.server_response)
         return response
 
 
-class EstValidationRequestController(TransferTicketRequestController):
+class EstValidationRequestController(TransferticketRequestController):
     _PYERIC_CONTROLLER = EstValidationPyericProcessController
 
     def __init__(self, input_data: EstData, include_elster_responses: bool = False):
@@ -135,7 +135,7 @@ class EstRequestController(EstValidationRequestController):
         return response
 
 
-class UnlockCodeRequestController(TransferTicketRequestController):
+class UnlockCodeRequestController(TransferticketRequestController):
     _PYERIC_CONTROLLER = UnlockCodeRequestPyericProcessController
 
     def __init__(self, input_data: UnlockCodeRequestData, include_elster_responses: bool = False):
@@ -155,7 +155,7 @@ class UnlockCodeRequestController(TransferTicketRequestController):
         return response
 
 
-class UnlockCodeActivationRequestController(TransferTicketRequestController):
+class UnlockCodeActivationRequestController(TransferticketRequestController):
     _PYERIC_CONTROLLER = UnlockCodeActivationPyericProcessController
 
     def generate_full_xml(self, use_testmerker):
@@ -169,7 +169,7 @@ class UnlockCodeActivationRequestController(TransferTicketRequestController):
         return response
 
 
-class UnlockCodeRevocationRequestController(TransferTicketRequestController):
+class UnlockCodeRevocationRequestController(TransferticketRequestController):
     _PYERIC_CONTROLLER = UnlockCodeRevocationPyericProcessController
 
     def generate_full_xml(self, use_testmerker):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -65,11 +65,11 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
     request_id = uuid.uuid4()
     tax_id_number = "test_idnr"
     elster_request_id = "test_elster_request_id"
-    transferticket = "test_transfer_ticket"
+    transferticket = "test_transferticket"
     erica_request = EricaRequest(type=request_type, status=Status.success,
                                  payload={"tax_id_number": tax_id_number},
                                  result={"elster_request_id": elster_request_id,
-                                         "transfer_ticket": transferticket},
+                                         "transferticket": transferticket},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.fsc.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -87,10 +87,10 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
 async def test_if_get_fsc_revocation_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     tax_id_number = "test_idnr"
-    transferticket = "test_transfer_ticket"
+    transferticket = "test_transferticket"
     erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
                                  payload={"tax_id_number": tax_id_number},
-                                 result={"transfer_ticket": transferticket, "idnr": tax_id_number},
+                                 result={"transferticket": transferticket, "idnr": tax_id_number},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.fsc.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -125,10 +125,10 @@ async def test_if_get_tax_validity_job_returns_success_status_with_result():
 async def test_if_get_send_est_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     pdf = "test_pdf"
-    transferticket = "test_transfer_ticket"
+    transferticket = "test_transferticket"
     erica_request = EricaRequest(type=RequestType.send_est, status=Status.success,
                                  payload={},
-                                 result={"transfer_ticket": transferticket, "pdf": pdf},
+                                 result={"transferticket": transferticket, "pdf": pdf},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.est.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -145,10 +145,10 @@ async def test_if_get_send_est_job_returns_success_status_with_result():
 async def test_if_get_grundsteuer_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     pdf = "test_pdf"
-    transferticket = "test_transfer_ticket"
+    transferticket = "test_transferticket"
     erica_request = EricaRequest(type=RequestType.grundsteuer, status=Status.success,
                                  payload={},
-                                 result={"transfer_ticket": transferticket, "pdf": pdf},
+                                 result={"transferticket": transferticket, "pdf": pdf},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.grundsteuer.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -65,11 +65,11 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
     request_id = uuid.uuid4()
     tax_id_number = "test_idnr"
     elster_request_id = "test_elster_request_id"
-    transfer_ticket = "test_transfer_ticket"
+    transferticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=request_type, status=Status.success,
                                  payload={"tax_id_number": tax_id_number},
                                  result={"elster_request_id": elster_request_id,
-                                         "transfer_ticket": transfer_ticket},
+                                         "transfer_ticket": transferticket},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.fsc.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -78,7 +78,7 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
         assert response.processStatus == JobState.SUCCESS
         assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
@@ -87,10 +87,10 @@ async def test_if_get_fsc_request_or_activation_job_returns_success_status_with_
 async def test_if_get_fsc_revocation_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     tax_id_number = "test_idnr"
-    transfer_ticket = "test_transfer_ticket"
+    transferticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
                                  payload={"tax_id_number": tax_id_number},
-                                 result={"transfer_ticket": transfer_ticket, "idnr": tax_id_number},
+                                 result={"transfer_ticket": transferticket, "idnr": tax_id_number},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.fsc.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -98,7 +98,7 @@ async def test_if_get_fsc_revocation_job_returns_success_status_with_result():
         response = await get_fsc_revocation_job(request_id)
         assert response.processStatus == JobState.SUCCESS
         assert response.result.idnr == tax_id_number
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
@@ -125,10 +125,10 @@ async def test_if_get_tax_validity_job_returns_success_status_with_result():
 async def test_if_get_send_est_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     pdf = "test_pdf"
-    transfer_ticket = "test_transfer_ticket"
+    transferticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=RequestType.send_est, status=Status.success,
                                  payload={},
-                                 result={"transfer_ticket": transfer_ticket, "pdf": pdf},
+                                 result={"transfer_ticket": transferticket, "pdf": pdf},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.est.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -136,7 +136,7 @@ async def test_if_get_send_est_job_returns_success_status_with_result():
         response = await get_send_est_job(request_id)
         assert response.processStatus == JobState.SUCCESS
         assert response.result.pdf == pdf
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
@@ -145,10 +145,10 @@ async def test_if_get_send_est_job_returns_success_status_with_result():
 async def test_if_get_grundsteuer_job_returns_success_status_with_result():
     request_id = uuid.uuid4()
     pdf = "test_pdf"
-    transfer_ticket = "test_transfer_ticket"
+    transferticket = "test_transfer_ticket"
     erica_request = EricaRequest(type=RequestType.grundsteuer, status=Status.success,
                                  payload={},
-                                 result={"transfer_ticket": transfer_ticket, "pdf": pdf},
+                                 result={"transfer_ticket": transferticket, "pdf": pdf},
                                  request_id=request_id, creator_id="test")
     with patch("erica.api.v2.endpoints.grundsteuer.get_service", MagicMock()) as get_service_mock:
         mock_service = MagicMock(get_request_by_request_id=MagicMock(return_value=erica_request))
@@ -156,7 +156,7 @@ async def test_if_get_grundsteuer_job_returns_success_status_with_result():
         response = await get_grundsteuer_job(request_id)
         assert response.processStatus == JobState.SUCCESS
         assert response.result.pdf == pdf
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 

--- a/tests/application/FreischaltCode/test_freischaltcode_jobs.py
+++ b/tests/application/FreischaltCode/test_freischaltcode_jobs.py
@@ -14,7 +14,7 @@ from erica.domain.FreischaltCode.FreischaltCode import FreischaltCodeActivatePay
 from erica.domain.Shared.EricaRequest import RequestType
 from erica.domain.erica_request.erica_request import EricaRequest
 from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_antrag_id_from_xml, \
-    get_transfer_ticket_from_xml
+    get_transferticket_from_xml
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from tests.utils import read_text_from_sample
 
@@ -87,7 +87,7 @@ class TestIntegrationWithDatabaseAndRequestFreischaltcode:
 
         assert updated_entity.result == {'elster_request_id': get_antrag_id_from_xml(xml_string),
                                          'idnr': payload.tax_id_number,
-                                         'transfer_ticket': get_transfer_ticket_from_xml(xml_string)}
+                                         'transferticket': get_transferticket_from_xml(xml_string)}
 
 
 class TestActivateFreischaltcode:
@@ -158,7 +158,7 @@ class TestIntegrationWithDatabaseAndActivateFreischaltcode:
 
         assert updated_entity.result == {'elster_request_id': get_antrag_id_from_xml(xml_string),
                                          'idnr': payload.tax_id_number,
-                                         'transfer_ticket': get_transfer_ticket_from_xml(xml_string)}
+                                         'transferticket': get_transferticket_from_xml(xml_string)}
 
 
 class TestRevocateFreischaltcode:
@@ -228,5 +228,5 @@ class TestIntegrationWithDatabaseAndRevocateFreischaltcode:
         updated_entity = service.repository.get_by_job_request_id(entity.request_id)
 
         assert updated_entity.result == {'elster_request_id': get_antrag_id_from_xml(xml_string),
-                                         'transfer_ticket': get_transfer_ticket_from_xml(xml_string)}
+                                         'transferticket': get_transferticket_from_xml(xml_string)}
 

--- a/tests/application/FreischaltCode/test_freischaltcode_service.py
+++ b/tests/application/FreischaltCode/test_freischaltcode_service.py
@@ -108,11 +108,11 @@ class TestFreischaltCodeService:
     def test_fsc_request_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
-        transferticket = "test_transfer_ticket"
+        transferticket = "test_transferticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_request, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
-                                             "transfer_ticket": transferticket},
+                                             "transferticket": transferticket},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -128,11 +128,11 @@ class TestFreischaltCodeService:
     def test_fsc_activate_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
-        transferticket = "test_transfer_ticket"
+        transferticket = "test_transferticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_activate, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
-                                             "transfer_ticket": transferticket},
+                                             "transferticket": transferticket},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -147,10 +147,10 @@ class TestFreischaltCodeService:
 
     def test_fsc_revocate_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
-        transferticket = "test_transfer_ticket"
+        transferticket = "test_transferticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
-                                     result={"transfer_ticket": transferticket, "idnr": tax_id_number},
+                                     result={"transferticket": transferticket, "idnr": tax_id_number},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)

--- a/tests/application/FreischaltCode/test_freischaltcode_service.py
+++ b/tests/application/FreischaltCode/test_freischaltcode_service.py
@@ -108,11 +108,11 @@ class TestFreischaltCodeService:
     def test_fsc_request_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
-        transfer_ticket = "test_transfer_ticket"
+        transferticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_request, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
-                                             "transfer_ticket": transfer_ticket},
+                                             "transfer_ticket": transferticket},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -121,18 +121,18 @@ class TestFreischaltCodeService:
         assert response.processStatus == JobState.SUCCESS
         assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
     def test_fsc_activate_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
         elster_request_id = "test_elster_request_id"
-        transfer_ticket = "test_transfer_ticket"
+        transferticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_activate, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
                                      result={"elster_request_id": elster_request_id,
-                                             "transfer_ticket": transfer_ticket},
+                                             "transfer_ticket": transferticket},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -141,16 +141,16 @@ class TestFreischaltCodeService:
         assert response.processStatus == JobState.SUCCESS
         assert response.result.idnr == tax_id_number
         assert response.result.elster_request_id == elster_request_id
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None
 
     def test_fsc_revocate_if_erica_request_found_and_success_then_return_success_response_dto(self):
         tax_id_number = "test_idnr"
-        transfer_ticket = "test_transfer_ticket"
+        transferticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.freischalt_code_revocate, status=Status.success,
                                      payload={"tax_id_number": tax_id_number},
-                                     result={"transfer_ticket": transfer_ticket, "idnr": tax_id_number},
+                                     result={"transfer_ticket": transferticket, "idnr": tax_id_number},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -158,6 +158,6 @@ class TestFreischaltCodeService:
         response = FreischaltCodeService(service=mock_service).get_response_freischaltcode_revocation("test")
         assert response.processStatus == JobState.SUCCESS
         assert response.result.idnr == tax_id_number
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None

--- a/tests/application/grundsteuer/test_grundsteuer_jobs.py
+++ b/tests/application/grundsteuer/test_grundsteuer_jobs.py
@@ -10,7 +10,7 @@ from erica.application.JobService.job_service_factory import get_job_service
 from erica.application.grundsteuer.grundsteuer_jobs import send_grundsteuer
 from erica.domain.Shared.EricaRequest import RequestType
 from erica.domain.erica_request.erica_request import EricaRequest
-from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_transfer_ticket_from_xml
+from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_transferticket_from_xml
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from tests.erica_legacy.samples.grundsteuer_sample_data import SampleGrundsteuerData
 from tests.utils import read_text_from_sample
@@ -84,5 +84,5 @@ class TestIntegrationWithDatabaseAndGrundsteuerJob:
 
         updated_entity = service.repository.get_by_job_request_id(entity.request_id)
 
-        assert updated_entity.result == {'transfer_ticket': get_transfer_ticket_from_xml(xml_string),
+        assert updated_entity.result == {'transferticket': get_transferticket_from_xml(xml_string),
                                          'pdf': expected_pdf}

--- a/tests/application/grundsteuer/test_grundsteuer_service.py
+++ b/tests/application/grundsteuer/test_grundsteuer_service.py
@@ -45,10 +45,10 @@ class TestGrundsteuerService:
 
     def test_if_erica_request_found_and_success_then_return_success_response_dto(self):
         pdf = "test_pdf"
-        transfer_ticket = "test_transfer_ticket"
+        transferticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.grundsteuer, status=Status.success,
                                      payload={},
-                                     result={"transfer_ticket": transfer_ticket, "pdf": pdf},
+                                     result={"transfer_ticket": transferticket, "pdf": pdf},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -56,6 +56,6 @@ class TestGrundsteuerService:
         response = GrundsteuerService(service=mock_service).get_response_grundsteuer("test")
         assert response.processStatus == JobState.SUCCESS
         assert response.result.pdf == pdf
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None

--- a/tests/application/grundsteuer/test_grundsteuer_service.py
+++ b/tests/application/grundsteuer/test_grundsteuer_service.py
@@ -45,10 +45,10 @@ class TestGrundsteuerService:
 
     def test_if_erica_request_found_and_success_then_return_success_response_dto(self):
         pdf = "test_pdf"
-        transferticket = "test_transfer_ticket"
+        transferticket = "test_transferticket"
         erica_request = EricaRequest(type=RequestType.grundsteuer, status=Status.success,
                                      payload={},
-                                     result={"transfer_ticket": transferticket, "pdf": pdf},
+                                     result={"transferticket": transferticket, "pdf": pdf},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)

--- a/tests/application/tax_declaration/test_tax_declaration_jobs.py
+++ b/tests/application/tax_declaration/test_tax_declaration_jobs.py
@@ -11,7 +11,7 @@ from erica.application.tax_declaration.tax_declaration_jobs import send_est
 from erica.domain.Shared.EricaRequest import RequestType
 from erica.domain.TaxDeclaration.TaxDeclaration import TaxDeclarationPayload
 from erica.domain.erica_request.erica_request import EricaRequest
-from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_transfer_ticket_from_xml
+from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_transferticket_from_xml
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from erica.erica_legacy.request_processing.erica_input.v1.erica_input import MetaDataEst
 from tests.erica_legacy.utils import TEST_EST_VERANLAGUNGSJAHR
@@ -88,5 +88,5 @@ class TestIntegrationWithDatabaseAndTaxDeclarationJob:
 
         updated_entity = service.repository.get_by_job_request_id(entity.request_id)
 
-        assert updated_entity.result == {'transfer_ticket': get_transfer_ticket_from_xml(xml_string),
+        assert updated_entity.result == {'transferticket': get_transferticket_from_xml(xml_string),
                                          'pdf': expected_pdf}

--- a/tests/application/tax_declaration/test_tax_declaration_service.py
+++ b/tests/application/tax_declaration/test_tax_declaration_service.py
@@ -45,10 +45,10 @@ class TestTaxDeclarationService:
 
     def test_if_erica_request_found_and_success_then_return_success_response_dto(self):
         pdf = "test_pdf"
-        transferticket = "test_transfer_ticket"
+        transferticket = "test_transferticket"
         erica_request = EricaRequest(type=RequestType.send_est, status=Status.success,
                                      payload={},
-                                     result={"transfer_ticket": transferticket, "pdf": pdf},
+                                     result={"transferticket": transferticket, "pdf": pdf},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)

--- a/tests/application/tax_declaration/test_tax_declaration_service.py
+++ b/tests/application/tax_declaration/test_tax_declaration_service.py
@@ -45,10 +45,10 @@ class TestTaxDeclarationService:
 
     def test_if_erica_request_found_and_success_then_return_success_response_dto(self):
         pdf = "test_pdf"
-        transfer_ticket = "test_transfer_ticket"
+        transferticket = "test_transfer_ticket"
         erica_request = EricaRequest(type=RequestType.send_est, status=Status.success,
                                      payload={},
-                                     result={"transfer_ticket": transfer_ticket, "pdf": pdf},
+                                     result={"transfer_ticket": transferticket, "pdf": pdf},
                                      request_id=uuid.uuid4(),
                                      creator_id="test")
         mock_get_request_by_request_id = MagicMock(return_value=erica_request)
@@ -56,6 +56,6 @@ class TestTaxDeclarationService:
         response = TaxDeclarationService(service=mock_service).get_response_send_est("test")
         assert response.processStatus == JobState.SUCCESS
         assert response.result.pdf == pdf
-        assert response.result.transfer_ticket == transfer_ticket
+        assert response.result.transferticket == transferticket
         assert response.errorCode is None
         assert response.errorMessage is None

--- a/tests/erica_legacy/elster_xml/xml_parsing/test_elster_tax_offices_xml_parsing.py
+++ b/tests/erica_legacy/elster_xml/xml_parsing/test_elster_tax_offices_xml_parsing.py
@@ -1,7 +1,7 @@
 import unittest
 
 from erica.erica_legacy.elster_xml.xml_parsing.elster_specifics_xml_parsing import get_state_ids, get_tax_offices, \
-    get_antrag_id_from_xml, get_idnr_from_xml, get_transfer_ticket_from_xml, get_address_from_xml, \
+    get_antrag_id_from_xml, get_idnr_from_xml, get_transferticket_from_xml, get_address_from_xml, \
     get_relevant_beleg_ids
 from tests.erica_legacy.utils import replace_text_in_xml
 from tests.utils import read_text_from_sample
@@ -48,16 +48,16 @@ class TestIdNrFromXml(unittest.TestCase):
         self.assertEqual(idnr, '04452397687')
 
 
-class TestTransferTicketFromXml(unittest.TestCase):
-    def test_if_correct_server_response_then_return_correct_transfer_ticket_value(self):
-        expected_transfer_ticket = 'Transferiates'
-        xml_string = replace_text_in_xml(read_text_from_sample('sample_vast_request_response.xml'), 'TransferTicket', expected_transfer_ticket)
-        actual_transfer_ticket = get_transfer_ticket_from_xml(xml_string)
-        self.assertEqual(expected_transfer_ticket, actual_transfer_ticket)
+class TestTransferticketFromXml(unittest.TestCase):
+    def test_if_correct_server_response_then_return_correct_transferticket_value(self):
+        expected_transferticket = 'Transferiates'
+        xml_string = replace_text_in_xml(read_text_from_sample('sample_vast_request_response.xml'), 'TransferTicket', expected_transferticket)
+        actual_transferticket = get_transferticket_from_xml(xml_string)
+        self.assertEqual(expected_transferticket, actual_transferticket)
 
 
 class TestAddressFromXml(unittest.TestCase):
-    def test_if_correct_server_response_then_return_correct_transfer_ticket_value(self):
+    def test_if_correct_server_response_then_return_correct_transferticket_value(self):
         import html
         expected_address = html.unescape('<AdrKette>'
                                          '<StrAdr>'

--- a/tests/erica_legacy/request_processing/test_grundsteuer_request_controller.py
+++ b/tests/erica_legacy/request_processing/test_grundsteuer_request_controller.py
@@ -75,10 +75,10 @@ class TestGenerateJson:
     def test_result_includes_all_relevant_aspects(self, valid_grundsteuer_request_controller):
         valid_grundsteuer_request_controller.include_elster_responses = True
         example_pyeric_response = PyericResponse("eric response", "server response", "pdf content".encode())
-        with patch('erica.erica_legacy.request_processing.requests_controller.get_transfer_ticket_from_xml',
-                   MagicMock(return_value='transfer ticket')):
+        with patch('erica.erica_legacy.request_processing.requests_controller.get_transferticket_from_xml',
+                   MagicMock(return_value='transferticket')):
             result = valid_grundsteuer_request_controller.generate_json(example_pyeric_response)
             assert result['pdf'] == base64.b64encode(b"pdf content").decode('utf-8')
-            assert result['transfer_ticket'] == 'transfer ticket'
+            assert result['transferticket'] == 'transferticket'
             assert result['eric_response'] == 'eric response'
             assert result['server_response'] == 'server response'

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -182,7 +182,7 @@ class TestEstRequestProcess(unittest.TestCase):
     @pytest.mark.skipif(missing_cert(), reason="skipped because of missing cert.pfx; see pyeric/README.md")
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
     def test_if_full_form_and_include_elster_responses_then_return_response_only_with_correct_keys(self):
-        expected_keys = ['transfer_ticket', 'pdf', 'eric_response', 'server_response']
+        expected_keys = ['transferticket', 'pdf', 'eric_response', 'server_response']
 
         est_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=True)
 
@@ -193,7 +193,7 @@ class TestEstRequestProcess(unittest.TestCase):
     @pytest.mark.skipif(missing_cert(), reason="skipped because of missing cert.pfx; see pyeric/README.md")
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
     def test_if_full_form_and_not_include_elster_responses_then_return_response_with_correct_keys(self):
-        expected_keys = ['transfer_ticket', 'pdf']
+        expected_keys = ['transferticket', 'pdf']
 
         est_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=False)
 
@@ -205,18 +205,18 @@ class TestEstRequestProcess(unittest.TestCase):
 class TestEstRequestGenerateJson(unittest.TestCase):
 
     def setUp(self):
-        self.expected_transfer_ticket = 'J-KLAPAUCIUS'
+        self.expected_transferticket = 'J-KLAPAUCIUS'
         self.pdf_bytes = b"Our lives begin the day we become silent about things that matter"
         self.expected_pdf = base64.b64encode(self.pdf_bytes).decode('utf-8')
         self.expected_eric_response = "We are now faced with the fact that tomorrow is today."
-        response_with_correct_transfer_ticket = replace_text_in_xml(
+        response_with_correct_transferticket = replace_text_in_xml(
             read_text_from_sample('sample_est_response_server.xml'),
-            'TransferTicket', self.expected_transfer_ticket)
-        self.expected_server_response = response_with_correct_transfer_ticket
+            'TransferTicket', self.expected_transferticket)
+        self.expected_server_response = response_with_correct_transferticket
 
     def test_if_id_given_and_include_true_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'pdf': self.expected_pdf,
             'eric_response': self.expected_eric_response,
             'server_response': self.expected_server_response
@@ -231,7 +231,7 @@ class TestEstRequestGenerateJson(unittest.TestCase):
 
     def test_if_id_given_and_include_false_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'pdf': self.expected_pdf
         }
         est_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=False)
@@ -348,17 +348,17 @@ class TestUnlockCodeRequestGenerateJson(unittest.TestCase):
 
     def setUp(self):
         self.expected_request_id = 'J-KLAPAUCIUS'
-        self.expected_transfer_ticket = 'Transferiato'
+        self.expected_transferticket = 'Transferiato'
         self.expected_idnr = "123456789"
         self.expected_eric_response = "We are now faced with the fact that tomorrow is today."
-        response_with_correct_transfer_ticket = replace_text_in_xml(
+        response_with_correct_transferticket = replace_text_in_xml(
             read_text_from_sample('sample_vast_request_response.xml'),
-            'TransferTicket', self.expected_transfer_ticket)
-        self.expected_server_response = response_with_correct_transfer_ticket
+            'TransferTicket', self.expected_transferticket)
+        self.expected_server_response = response_with_correct_transferticket
 
     def test_if_id_given_and_include_true_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id,
             'idnr': self.expected_idnr,
             'eric_response': self.expected_eric_response,
@@ -377,7 +377,7 @@ class TestUnlockCodeRequestGenerateJson(unittest.TestCase):
 
     def test_if_id_given_and_include_false_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id,
             'idnr': self.expected_idnr,
         }
@@ -406,19 +406,19 @@ class TestUnlockCodeRequestGenerateJson(unittest.TestCase):
 
         self.assertEqual(expected_elster_request_id, actual_response['elster_request_id'])
 
-    def test_if_eric_process_successful_then_return_correct_transfer_ticket(self):
+    def test_if_eric_process_successful_then_return_correct_transferticket(self):
         unlock_code_request = UnlockCodeRequestController(UnlockCodeRequestData(
             idnr=self.expected_idnr,
             dob=date(1985, 1, 1)), include_elster_responses=False)
-        expected_transfer_ticket = "PizzaAndNutCake"
+        expected_transferticket = "PizzaAndNutCake"
 
         successful_server_response = replace_text_in_xml(read_text_from_sample('sample_vast_request_response.xml', 'r'),
-                                                         "TransferTicket", expected_transfer_ticket)
+                                                         "TransferTicket", expected_transferticket)
 
         pyeric_response = PyericResponse('eric_response', successful_server_response)
         actual_response = unlock_code_request.generate_json(pyeric_response)
 
-        self.assertEqual(expected_transfer_ticket, actual_response['transfer_ticket'])
+        self.assertEqual(expected_transferticket, actual_response['transferticket'])
 
 
 class TestUnlockCodeActivationProcess(unittest.TestCase):
@@ -501,16 +501,16 @@ class TestUnlockCodeActivationGenerateJson(unittest.TestCase):
     def setUp(self):
         self.expected_idnr = "123456789"
         self.expected_request_id = 'J-KLAPAUCIUS'
-        self.expected_transfer_ticket = 'Transfiguration'
+        self.expected_transferticket = 'Transfiguration'
         self.expected_eric_response = "We are now faced with the fact that tomorrow is today."
-        response_with_correct_transfer_ticket = replace_text_in_xml(
+        response_with_correct_transferticket = replace_text_in_xml(
             read_text_from_sample('sample_vast_activation_response.xml'),
-            'TransferTicket', self.expected_transfer_ticket)
-        self.expected_server_response = response_with_correct_transfer_ticket
+            'TransferTicket', self.expected_transferticket)
+        self.expected_server_response = response_with_correct_transferticket
 
     def test_if_id_given_and_include_true_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id,
             'idnr': self.expected_idnr,
             'eric_response': self.expected_eric_response,
@@ -530,7 +530,7 @@ class TestUnlockCodeActivationGenerateJson(unittest.TestCase):
 
     def test_if_id_given_and_include_false_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id,
             'idnr': self.expected_idnr,
         }
@@ -545,20 +545,20 @@ class TestUnlockCodeActivationGenerateJson(unittest.TestCase):
 
         self.assertEqual(expected_output, actual_response)
 
-    def test_if_eric_process_successful_then_return_correct_transfer_ticket(self):
-        expected_transfer_ticket = "PizzaAndNutCake"
+    def test_if_eric_process_successful_then_return_correct_transferticket(self):
+        expected_transferticket = "PizzaAndNutCake"
         unlock_code_activation = UnlockCodeActivationRequestController(UnlockCodeActivationData(
             idnr=self.expected_idnr,
             unlock_code='1985-T67D-K89O',
             elster_request_id='42'), include_elster_responses=False)
 
         successful_server_response = replace_text_in_xml(read_text_from_sample('sample_vast_activation_response.xml'),
-                                                         "TransferTicket", expected_transfer_ticket)
+                                                         "TransferTicket", expected_transferticket)
 
         pyeric_response = PyericResponse('eric_response', successful_server_response)
         actual_response = unlock_code_activation.generate_json(pyeric_response)
 
-        self.assertEqual(expected_transfer_ticket, actual_response['transfer_ticket'])
+        self.assertEqual(expected_transferticket, actual_response['transferticket'])
 
 
 class TestUnlockCodeRevocationProcess(unittest.TestCase):
@@ -638,16 +638,16 @@ class TestUnlockCodeRevocationGenerateJson(unittest.TestCase):
     def setUp(self):
         self.expected_idnr = "123456789"
         self.expected_request_id = 'J-KLAPAUCIUS'
-        self.expected_transfer_ticket = 'The time is always right to do what is right.'
+        self.expected_transferticket = 'The time is always right to do what is right.'
         self.expected_eric_response = "We are now faced with the fact that tomorrow is today."
-        response_with_correct_transfer_ticket = replace_text_in_xml(
+        response_with_correct_transferticket = replace_text_in_xml(
             read_text_from_sample('sample_vast_revocation_response.xml'),
-            'TransferTicket', self.expected_transfer_ticket)
-        self.expected_server_response = response_with_correct_transfer_ticket
+            'TransferTicket', self.expected_transferticket)
+        self.expected_server_response = response_with_correct_transferticket
 
     def test_if_id_given_and_include_true_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id,
             'eric_response': self.expected_eric_response,
             'server_response': self.expected_server_response
@@ -665,7 +665,7 @@ class TestUnlockCodeRevocationGenerateJson(unittest.TestCase):
 
     def test_if_id_given_and_include_false_then_return_json_with_correct_info(self):
         expected_output = {
-            'transfer_ticket': self.expected_transfer_ticket,
+            'transferticket': self.expected_transferticket,
             'elster_request_id': self.expected_request_id
         }
         unlock_code_request = UnlockCodeRevocationRequestController(UnlockCodeRevocationData(
@@ -679,19 +679,19 @@ class TestUnlockCodeRevocationGenerateJson(unittest.TestCase):
 
         self.assertEqual(expected_output, actual_response)
 
-    def test_if_eric_process_successful_then_return_correct_transfer_ticket(self):
-        expected_transfer_ticket = "PizzaAndNutCake"
+    def test_if_eric_process_successful_then_return_correct_transferticket(self):
+        expected_transferticket = "PizzaAndNutCake"
         unlock_code_revocation = UnlockCodeRevocationRequestController(UnlockCodeRevocationData(idnr=self.expected_idnr,
                                                                                                 elster_request_id='42'),
                                                                        include_elster_responses=False)
 
         successful_server_response = replace_text_in_xml(read_text_from_sample('sample_vast_revocation_response.xml'),
-                                                         "TransferTicket", expected_transfer_ticket)
+                                                         "TransferTicket", expected_transferticket)
 
         pyeric_response = PyericResponse('eric_response', successful_server_response)
         actual_response = unlock_code_revocation.generate_json(pyeric_response)
 
-        self.assertEqual(expected_transfer_ticket, actual_response['transfer_ticket'])
+        self.assertEqual(expected_transferticket, actual_response['transferticket'])
 
 
 class TestCheckTaxNumberRequestControllerProcess:


### PR DESCRIPTION
# Short Description
- Transferticket is actually one word, so why not export it as one word from Erica?

# Changes
- Adapt the outputted data to use `transferticket` instead of `transfer_ticket`
- Add a check for transferticket (+pdf) in the contract tests (which didn't fail with my changes which I had expected)

# Feedback
- Do you think I should adapt the other snake-case variables, too? (in this PR?)
- Do you think it's be better to change all occurrences of transfer_ticket to transferticket, also in the deeper code (aka "legacy" folder)?
- Do you see a problem with pushing this? Rente is still using the v1, correct? So this should not be a problem? @SannyNguyenHung 

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
