### PR TITLE
Generate aktenzeichen for all bundeslaender

### DIFF
--- a/erica/erica_legacy/elster_xml/grundsteuer/elster_data_representation.py
+++ b/erica/erica_legacy/elster_xml/grundsteuer/elster_data_representation.py
@@ -162,16 +162,16 @@ class EVorsatz:
         self.AbsOrt = input_data.eigentuemer.person[0].adresse.ort
         self.Copyright = "(C) 2022 DigitalService4Germany"
 
+        steuernummer_aktenzeichen = generate_electronic_aktenzeichen(input_data.grundstueck.steuernummer,
+                                                                     input_data.grundstueck.adresse.bundesland)
         if input_data.grundstueck.adresse.bundesland in BUNDESLAENDER_WITH_STEUERNUMMER:
             self.OrdNrArt = "S"
-            self.StNr = generate_electronic_steuernummer(input_data.grundstueck.steuernummer,
-                                                         input_data.grundstueck.adresse.bundesland)
+            self.StNr = steuernummer_aktenzeichen
             self.Aktenzeichen = None
         else:
             self.OrdNrArt = "A"
             self.StNr = None
-            self.Aktenzeichen = generate_electronic_aktenzeichen(input_data.grundstueck.steuernummer,
-                                                                 input_data.grundstueck.adresse.bundesland)
+            self.Aktenzeichen = steuernummer_aktenzeichen
 
         self.Rueckuebermittlung = ERueckuebermittlung()
 

--- a/tests/erica_legacy/elster_xml/common/test_electronic_steuernummer.py
+++ b/tests/erica_legacy/elster_xml/common/test_electronic_steuernummer.py
@@ -26,9 +26,28 @@ class TestGetBufaNr:
 
 @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
 class TestGenerateElectronicAktenzeichen:
-    def test_gernerate_electronic_aktenzeichen(self):
-        result = generate_electronic_aktenzeichen("2080353038893", "NW")
-        assert result == '520850353038893'
+    @pytest.mark.parametrize("bl, input_stnr, expected_stnr", [
+        ("NW", "2080353038893", "520850353038893"),
+        ("BW", "3100190001250002", "2831400190001250002"),
+        ("BY", "19869040000000012", "9198469040000000012"),
+        ("BE", "1687412343", "1116087412343"),
+        ("BB", "09841275756757579", "3098441275756757579"),
+        ("HB", "5710392627", "2457010392627"),
+        ("HH", "1605432634", "2216005432634"),
+        ("HE", "6000190000020004", "2660400190000020004"),
+        ("MV", "09868000600010001", "4098468000600010001"),
+        ("NI", "7968000600010009", "2379468000600010009"),
+        ("NW", "6000353012851", "560050353012851"),
+        ("RP", "70100281052000010", "2701400281052000010"),
+        ("SL", "01031130640290128", "1010431130640290128"),
+        ("SH", "9800196641", "2198000196641"),
+        ("SN", "22491703400010006", "3224491703400010006"),
+        ("ST", "10220000150210005", "3102420000150210005"),
+        ("TH", "19801005430173326", "4198401005430173326")
+    ])
+    def test_generate_electronic_aktenzeichen(self, bl, input_stnr, expected_stnr):
+        result = generate_electronic_aktenzeichen(input_stnr, bl)
+        assert result == expected_stnr
 
 
 class TestGenerateElectronicSteuernummer:


### PR DESCRIPTION
# Short Description
- When implementing the feature, I didn't have Steuernummern/Aktenzeichen of all Bundesländer which is why I couldn't test the method properly. So I added tests with data from the Steuernummerprüfung-PDF from Elster, that includes exaples for each Bundesland.

# Changes
- Add tests for create_aktenzeichen
- Only use create_aktenzeichen, not steuernummer, as it turns out that Eric's function already handles the steuernummer cases correctly

# Feedback
- ?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
