### PR TITLE
Move validation problems into result response

### DIFF
--- a/contract_tests/test_integration_queue.py
+++ b/contract_tests/test_integration_queue.py
@@ -299,6 +299,72 @@ def full_grundsteuer_data():
 
 
 @pytest.fixture()
+def grundsteuer_data_with_validation_errors():
+    grundsteuer_payload = {
+        "grundstueck": {
+            "typ": "baureif",
+            "adresse": {
+                "strasse": "GST Strasse",
+                "hausnummer": "2",
+                "hausnummerzusatz": "GST",
+                "zusatzangaben": "GST Zusatzangaben",
+                "plz": "12345",
+                "ort": "GST Ort",
+                "bundesland": "BB"
+            },
+            "steuernummer": "09841275756757579",
+            "innerhalbEinerGemeinde": "true",
+            "bodenrichtwert": "123,00",
+            "flurstueck": [
+                {
+                    "angaben": {
+                        "grundbuchblattnummer": "1",
+                        "gemarkung": "2"
+                    },
+                    "flur": {
+                        "flur": "1",
+                        "flurstueckZaehler": "23",
+                        "flurstueckNenner": "45",
+                        "wirtschaftlicheEinheitZaehler": "67.1000",
+                        "wirtschaftlicheEinheitNenner": "89"
+                    },
+                    "groesseQm": "1234"
+                }
+            ]
+        },
+        "eigentuemer": {
+            "person": [
+                {
+                    "persoenlicheAngaben": {
+                        "anrede": "frau",
+                        "titel": "1 Titel",
+                        "vorname": "1 Vorname",
+                        "name": "1 Name",
+                        "geburtsdatum": "1980-01-31"
+                    },
+                    "adresse": {
+                        # ILLEGAL TO HAND STRASSE + POSTFACH
+                        "postfach": "123456",
+                        "strasse": "1 Strasse",
+                        "hausnummer": "1",
+                        "hausnummerzusatz": "Hausnummer",
+                        "plz": "12345",
+                        "ort": "1 Ort"
+                    },
+                    "telefonnummer": "111111",
+                    "steuerId": "04452397687",
+                    "anteil": {
+                        "zaehler": "1",
+                        "nenner": "2"
+                    }
+                }
+            ],
+        }
+    }
+    return build_request_data(grundsteuer_payload)
+
+
+@pytest.fixture()
 def full_unlock_code_request_data():
     payload = {'tax_id_number': "04531972802",
                'date_of_birth': date(1957, 7, 14),
@@ -727,6 +793,20 @@ class TestV2GrundsteuerRequest:
         assert response.json()["result"] is not None
         assert response.json()["errorCode"] is None
         assert response.json()["errorMessage"] is None
+
+    def test_if_get_existing_request_with_validation_errors_then_return_200_and_response_with_correct_params(self, grundsteuer_data_with_validation_errors):
+        response = requests.post(ERICA_TESTING_URL + self.endpoint,
+                                 data=json.dumps(grundsteuer_data_with_validation_errors, default=json_default))
+        assert response.status_code == 201
+        uuid = response.headers['Location'].split("/")[2]
+        sleep(6)
+        response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
+        assert response.status_code == 200
+        assert response.json()["processStatus"] == "Failure"
+        assert response.json()["result"] is not None
+        assert response.json()["result"]["validation_errors"] is not None
+        assert response.json()["errorCode"] is not None
+        assert response.json()["errorMessage"] is not None
 
     def test_if_get_existing_request_with_wrong_request_type_then_return_404_wrong_request_type(self,
                                                                                                 full_unlock_code_activation_data):

--- a/contract_tests/test_integration_queue.py
+++ b/contract_tests/test_integration_queue.py
@@ -78,6 +78,50 @@ def full_est_data():
 
 
 @pytest.fixture()
+def est_data_with_validation_errors():
+    est_payload = {
+        'est_data': {
+            'steuernummer': '19811310010',
+            'submission_without_tax_nr': False,
+            'bufa_nr': '9198',
+            'bundesland': 'BY',
+            'familienstand': 'married',
+            'familienstand_date': date(2000, 1, 31),
+
+            'person_a_idnr': '04452397687',
+            'person_a_dob': date(1950, 8, 16),
+            'person_a_first_name': 'Manfred',
+            'person_a_last_name': 'Mustername',
+            'person_a_street': 'Steuerweg',
+            'person_a_street_number': 42,
+            'person_a_plz': 20354,
+            'person_a_town': 'Hamburg',
+            'person_a_religion': 'none',
+            'person_a_has_pflegegrad': False,
+            'person_a_has_merkzeichen_bl': False,
+            'person_a_has_merkzeichen_tbl': False,
+            'person_a_has_merkzeichen_h': False,
+            'person_a_has_merkzeichen_ag': False,
+            'person_a_has_merkzeichen_g': False,
+            'person_a_requests_pauschbetrag': False,
+            'person_a_requests_fahrtkostenpauschale': False,
+            'telephone_number': '01715151',
+
+            'iban': 'DE35133713370000012345',
+            'account_holder': 'person_b',
+
+            'confirm_complete_correct': True,
+            'confirm_send': True,
+        },
+        'meta_data': {
+            'year': 2021
+        }
+    }
+
+    return build_request_data(est_payload)
+
+
+@pytest.fixture()
 def full_grundsteuer_data():
     grundsteuer_payload = {
         "grundstueck": {
@@ -606,6 +650,21 @@ class TestV2SendEst:
         assert response.json()["result"]["transfer_ticket"] is not None
         assert response.json()["errorCode"] is None
         assert response.json()["errorMessage"] is None
+
+    def test_if_get_existing_request_with_validation_errors_then_return_200_and_response_with_correct_params(self, est_data_with_validation_errors):
+        response = requests.post(ERICA_TESTING_URL + self.endpoint,
+                                 data=json.dumps(est_data_with_validation_errors, default=str))
+        assert response.status_code == 201
+        uuid = response.headers['Location'].split("/")[2]
+        sleep(6)
+        response = requests.get(ERICA_TESTING_URL + self.endpoint + "/" + uuid)
+
+        assert response.status_code == 200
+        assert response.json()["processStatus"] == "Failure"
+        assert response.json()["result"] is not None
+        assert response.json()["result"]["validation_errors"] is not None
+        assert response.json()["errorCode"] is not None
+        assert response.json()["errorMessage"] is not None
 
     def test_if_get_existing_request_with_wrong_request_type_then_return_404_wrong_request_type(self,
                                                                                                 full_unlock_code_activation_data):

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -46,7 +46,8 @@ async def perform_job(request_id: UUID, repository: base_repository_interface, s
             )
             entity.error_code = e.generate_error_response().get('message')
             entity.error_message = e.generate_error_response().get('message')
-            entity.result = e.generate_error_response().get('validation_problems')
+            validation_problems = e.generate_error_response().get('validation_problems')
+            entity.result = {"validation_errors": validation_problems} if validation_problems else None
             entity.status = Status.failed
             repository.update(entity.id, entity)
             raise

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -45,7 +45,8 @@ async def perform_job(request_id: UUID, repository: base_repository_interface, s
                 exc_info=True
             )
             entity.error_code = e.generate_error_response().get('message')
-            entity.error_message = e.generate_error_response().get('validation_problems', e.generate_error_response().get('message'))
+            entity.error_message = e.generate_error_response().get('message')
+            entity.result = e.generate_error_response().get('validation_problems')
             entity.status = Status.failed
             repository.update(entity.id, entity)
             raise

--- a/erica/application/JobService/job.py
+++ b/erica/application/JobService/job.py
@@ -40,13 +40,14 @@ async def perform_job(request_id: UUID, repository: base_repository_interface, s
             entity.status = Status.success
             repository.update(entity.id, entity)
         except EricProcessNotSuccessful as e:
+            error_response = e.generate_error_response(True)
             logger.warning(
-                f"Job failed: {entity}. Got Error Message: {e.generate_error_response(True).__str__()}",
+                f"Job failed: {entity}. Got Error Message: {error_response.__str__()}",
                 exc_info=True
             )
-            entity.error_code = e.generate_error_response().get('message')
-            entity.error_message = e.generate_error_response().get('message')
-            validation_problems = e.generate_error_response().get('validation_problems')
+            entity.error_code = error_response.get('message')
+            entity.error_message = error_response.get('message')
+            validation_problems = error_response.get('validation_problems')
             entity.result = {"validation_errors": validation_problems} if validation_problems else None
             entity.status = Status.failed
             repository.update(entity.id, entity)

--- a/erica/application/Shared/response_dto.py
+++ b/erica/application/Shared/response_dto.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, List
 
 from erica.application.base_dto import BaseDto
 
@@ -25,3 +25,7 @@ class ResponseErrorDto(BaseDto):
 class ResultTransferPdfResponseDto(BaseDto):
     transfer_ticket: str
     pdf: str
+
+
+class ResultValidationErrorResponseDto(BaseDto):
+    validation_errors: List[str]

--- a/erica/application/grundsteuer/GrundsteuerService.py
+++ b/erica/application/grundsteuer/GrundsteuerService.py
@@ -32,7 +32,7 @@ class GrundsteuerService(GrundsteuerServiceInterface):
         elif process_status == JobState.FAILURE:
             return GrundsteuerResponseDto(
                 processStatus=map_status(erica_request.status), errorCode=erica_request.error_code,
-                errorMessage=erica_request.error_message)
+                errorMessage=erica_request.error_message, result=erica_request.result)
         else:
             return GrundsteuerResponseDto(
                 processStatus=map_status(erica_request.status))

--- a/erica/application/grundsteuer/grundsteuer_dto.py
+++ b/erica/application/grundsteuer/grundsteuer_dto.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Optional, Union
 
-from erica.application.Shared.response_dto import ResponseBaseDto, ResultTransferPdfResponseDto
+from erica.application.Shared.response_dto import ResponseBaseDto, ResultTransferPdfResponseDto, \
+    ResultValidationErrorResponseDto
 from erica.application.grundsteuer.grundsteuer_input_eigentuemer import Eigentuemer
 
 from erica.application.grundsteuer.camel_case_input import CamelCaseInput
@@ -28,4 +29,4 @@ class GrundsteuerDto(CamelCaseInput):
 # Output
 
 class GrundsteuerResponseDto(ResponseBaseDto):
-    result: Optional[ResultTransferPdfResponseDto]
+    result: Optional[Union[ResultTransferPdfResponseDto, ResultValidationErrorResponseDto]]

--- a/erica/application/grundsteuer/grundsteuer_input_grundstueck.py
+++ b/erica/application/grundsteuer/grundsteuer_input_grundstueck.py
@@ -34,7 +34,7 @@ class FlurstueckAngaben(CamelCaseInput):
 
 
 class Flur(CamelCaseInput):
-    flur: str
+    flur: Optional[str]
     flurstueck_zaehler: int
     flurstueck_nenner: Optional[str]
     # number with 1-6 integer digits and exactly 4 fractional digits with '.' as decimal separator, e.g.90.1234

--- a/erica/application/tax_declaration/TaxDeclarationService.py
+++ b/erica/application/tax_declaration/TaxDeclarationService.py
@@ -32,7 +32,7 @@ class TaxDeclarationService(TaxDeclarationServiceInterface):
         elif process_status == JobState.FAILURE:
             return EstResponseDto(
                 processStatus=map_status(erica_request.status), errorCode=erica_request.error_code,
-                errorMessage=erica_request.error_message)
+                errorMessage=erica_request.error_message, result=erica_request.result)
         else:
             return EstResponseDto(
                 processStatus=map_status(erica_request.status))

--- a/erica/application/tax_declaration/tax_declaration_dto.py
+++ b/erica/application/tax_declaration/tax_declaration_dto.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Optional, Union
 
-from erica.application.Shared.response_dto import ResponseBaseDto, ResultTransferPdfResponseDto
+from erica.application.Shared.response_dto import ResponseBaseDto, ResultTransferPdfResponseDto, \
+    ResultValidationErrorResponseDto
 from erica.application.base_dto import BaseDto
 from erica.erica_legacy.request_processing.erica_input.v1.erica_input import FormDataEst, MetaDataEst
 
@@ -20,4 +21,4 @@ class TaxDeclarationDto(BaseDto):
 # Output
 
 class EstResponseDto(ResponseBaseDto):
-    result: Optional[ResultTransferPdfResponseDto]
+    result: Optional[Union[ResultTransferPdfResponseDto, ResultValidationErrorResponseDto]]

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 
 from erica.application.JobService.job import perform_job
 from erica.domain.Shared.Status import Status
-from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful, EricGlobalValidationError
+from erica.erica_legacy.pyeric.eric_errors import EricProcessNotSuccessful, EricGlobalValidationError, EricTransferError
 from erica.infrastructure.sqlalchemy.repositories.base_repository import EntityNotFoundError
 
 
@@ -37,20 +37,21 @@ class TestJob:
 
     @pytest.mark.asyncio
     async def test_if_service_raises_error_then_update_entity_in_database_with_correct_values(self):
-        validation_problems = "These are not the Ericas you are looking for"
         mock_entity = MagicMock(id="R2-D2", request_id="C3PO")
         mock_get_by_job_request_id = MagicMock(return_value=mock_entity)
         mock_update = MagicMock()
         mock_repository = MagicMock(get_by_job_request_id=mock_get_by_job_request_id, update=mock_update)
-        mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricGlobalValidationError(
-            eric_response=f"<xml><Text>{validation_problems}</Text></xml>".encode())))
+        mock_service = MagicMock(apply_to_elster=MagicMock(side_effect=EricTransferError(
+            eric_response=f"<xml>Eric Response</xml>".encode(),
+            server_response=f"<xml>Server Response</xml>".encode())))
 
         with pytest.raises(EricProcessNotSuccessful):
             await perform_job(request_id=uuid4(), repository=mock_repository, service=mock_service,
                               payload_type=MagicMock(), logger=MagicMock())
 
         assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('message')
-        assert mock_entity.error_message == [validation_problems]
+        assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
+        assert mock_entity.result is None
         assert mock_entity.status == Status.failed
         assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
 
@@ -69,7 +70,8 @@ class TestJob:
                               payload_type=MagicMock(), logger=MagicMock())
 
         assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('message')
-        assert mock_entity.error_message == [validation_problems]
+        assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
+        assert mock_entity.result == [validation_problems]
         assert mock_entity.status == Status.failed
         assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
 

--- a/tests/application/job_service/test_job.py
+++ b/tests/application/job_service/test_job.py
@@ -71,7 +71,7 @@ class TestJob:
 
         assert mock_entity.error_code == EricProcessNotSuccessful().generate_error_response().get('message')
         assert mock_entity.error_message == EricProcessNotSuccessful().generate_error_response().get('message')
-        assert mock_entity.result == [validation_problems]
+        assert mock_entity.result == {'validation_errors': [validation_problems]}
         assert mock_entity.status == Status.failed
         assert mock_update.mock_calls == [call(mock_entity.id, mock_entity)]
 


### PR DESCRIPTION
# Short Description
- Before, the validation problems were stored in the `error_message` column of the result table. However, as this had a VARCHAR datatype they were stored like this: `"{"Error 1", "Error 2"}`
- Now, they instead get stored in the `result` column

# Changes
- Store validation_problems as dict in result + return as object
- Adapt test for non-validation errors no not include validation_problems

# Feedback
- Do we have any end-to-end tests that I should adapt to be sure this actually works as intended? Because so far, I think e.g. the ResponseDto is never actually tested?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
