### PR TITLE
Run cron jobs every minute

### DIFF
--- a/erica/cron.d/set_not_processed_entities_to_failed
+++ b/erica/cron.d/set_not_processed_entities_to_failed
@@ -1,2 +1,2 @@
 SHELL=/bin/bash
-*/5 * * * * root cd /app && /usr/local/bin/pipenv run python erica/infrastructure/sqlalchemy/cron/update_entities_utils.py set-not-processed-entities-to-failed &> /app/cronjob_not_processed_output
+* * * * * root cd /app && /usr/local/bin/pipenv run python erica/infrastructure/sqlalchemy/cron/update_entities_utils.py set-not-processed-entities-to-failed &> /app/cronjob_not_processed_output


### PR DESCRIPTION
# Short Description
To ensure that we file early enough the cron job should run more often. Before it could happen that it would take 7 minutes for a job to fail (not being processed (2 minutes waiting time), cron job will run after 5 minutes)

# Changes
- Reduce waiting time

# Feedback
- Do we need to adapt the other cron job, too?
- Does that make sense?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
