### PR TITLE
Make id number optional

### DIFF
--- a/erica/application/FreischaltCode/FreischaltCode.py
+++ b/erica/application/FreischaltCode/FreischaltCode.py
@@ -14,7 +14,7 @@ class FreischaltCodeRequestPayloadDto(BaseDto):
 
 
 class FreischaltCodeActivatePayloadDto(BaseDto):
-    tax_id_number: str
+    tax_id_number: Optional[str]
     freischalt_code: str
     elster_request_id: str
 
@@ -30,7 +30,7 @@ class FreischaltCodeActivateDto(BaseDto):
 
 
 class FreischaltCodeRevocatePayloadDto(BaseDto):
-    tax_id_number: str
+    tax_id_number: Optional[str]
     elster_request_id: str
 
 

--- a/erica/domain/FreischaltCode/FreischaltCode.py
+++ b/erica/domain/FreischaltCode/FreischaltCode.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from datetime import date
+from typing import Optional
 
 from erica.domain.Shared.BaseDomainModel import BasePayload
 
@@ -10,11 +11,11 @@ class FreischaltCodeRequestPayload(BasePayload, ABC):
 
 
 class FreischaltCodeActivatePayload(BasePayload, ABC):
-    tax_id_number: str
+    tax_id_number: Optional[str]
     freischalt_code: str
     elster_request_id: str
 
 
 class FreischaltCodeRevocatePayload(BasePayload, ABC):
-    tax_id_number: str
+    tax_id_number: Optional[str]
     elster_request_id: str

--- a/erica/erica_legacy/pyeric/check_elster_request_id.py
+++ b/erica/erica_legacy/pyeric/check_elster_request_id.py
@@ -4,6 +4,17 @@ from erica.erica_legacy.elster_xml import elster_xml_generator
 from erica.erica_legacy.elster_xml.xml_parsing.erica_xml_parsing import remove_declaration_and_namespace
 from erica.erica_legacy.pyeric.pyeric_controller import PermitListingPyericProcessController
 
+SPECIAL_TESTMERKER_IDNR = ['04452397687',
+                           '02259674819',
+                           '04452317681',
+                           '09952417688',
+                           '03352417692',
+                           '03352419681',
+                           '03352417981',
+                           '03392417683',
+                           '03352917681',
+                           '03359417681']
+
 NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
 
 
@@ -32,7 +43,7 @@ def get_list_vast_requests(pyeric_controller):
 
 
 def tax_id_number_is_test_id_number(tax_id_number):
-    return tax_id_number[0] == "0"
+    return tax_id_number in SPECIAL_TESTMERKER_IDNR
 
 
 def request_needs_testmerker(request_id):

--- a/erica/erica_legacy/pyeric/check_elster_request_id.py
+++ b/erica/erica_legacy/pyeric/check_elster_request_id.py
@@ -1,0 +1,41 @@
+from functools import lru_cache
+
+from erica.erica_legacy.elster_xml import elster_xml_generator
+from erica.erica_legacy.elster_xml.xml_parsing.erica_xml_parsing import remove_declaration_and_namespace
+from erica.erica_legacy.pyeric.pyeric_controller import PermitListingPyericProcessController
+
+NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
+
+
+def reset_new_request_id_list():
+    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
+    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
+
+
+def add_new_request_id_to_cache_list(request_id):
+    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
+    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION.append(request_id)
+
+
+def get_vast_list_from_xml(xml):
+    simple_xml = remove_declaration_and_namespace(xml)
+    return {antrag.find('.//AntragsID').text: antrag.find('.//DateninhaberIdNr').text for antrag in simple_xml.findall('.//Antrag')}
+
+
+@lru_cache
+def get_list_vast_requests(pyeric_controller):
+    xml = elster_xml_generator.generate_full_vast_list_xml()
+    result = pyeric_controller(xml=xml).get_eric_response()
+    vast_request_list = get_vast_list_from_xml(result.server_response)
+    reset_new_request_id_list()
+    return vast_request_list
+
+
+def tax_id_number_is_test_id_number(tax_id_number):
+    return tax_id_number[0] == "0"
+
+
+def request_needs_testmerker(request_id):
+    if request_id in NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION:
+        get_list_vast_requests.cache_clear()
+    return tax_id_number_is_test_id_number(get_list_vast_requests(PermitListingPyericProcessController).get(request_id))

--- a/erica/erica_legacy/pyeric/utils.py
+++ b/erica/erica_legacy/pyeric/utils.py
@@ -1,12 +1,45 @@
 import os
+from functools import lru_cache
 
-from xml.dom import minidom
+from erica.erica_legacy.elster_xml import elster_xml_generator
+from erica.erica_legacy.elster_xml.xml_parsing.erica_xml_parsing import remove_declaration_and_namespace
+from erica.erica_legacy.pyeric.pyeric_controller import PermitListingPyericProcessController
 
 _INSTANCES_FOLDER = os.path.join('erica', 'instances')
 _BLUEPRINT_FOLDER = os.path.join(_INSTANCES_FOLDER, 'blueprint')
 
+NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
 
-def pretty_xml_string(xml_string):
-    dom_string = minidom.parseString(xml_string).toprettyxml(indent=" " * 4)
-    return '\n'.join([s for s in dom_string.splitlines() if s.strip()])  # remove empty lines
 
+def reset_new_request_id_list():
+    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
+    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
+
+
+def add_new_request_id_to_cache_list(request_id):
+    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
+    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION.append(request_id)
+
+
+def get_vast_list_from_xml(xml):
+    simple_xml = remove_declaration_and_namespace(xml)
+    return {antrag.find('.//AntragsID').text: antrag.find('.//DateninhaberIdNr').text for antrag in simple_xml.findall('.//Antrag')}
+
+
+@lru_cache
+def get_list_vast_requests(pyeric_controller):
+    xml = elster_xml_generator.generate_full_vast_list_xml()
+    result = pyeric_controller(xml=xml).get_eric_response()
+    vast_request_list = get_vast_list_from_xml(result.server_response)
+    reset_new_request_id_list()
+    return vast_request_list
+
+
+def tax_id_number_is_test_id_number(tax_id_number):
+    return tax_id_number[0] == "0"
+
+
+def request_needs_testmerker(request_id):
+    if request_id in NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION:
+        get_list_vast_requests.cache_clear()
+    return tax_id_number_is_test_id_number(get_list_vast_requests(PermitListingPyericProcessController).get(request_id))

--- a/erica/erica_legacy/pyeric/utils.py
+++ b/erica/erica_legacy/pyeric/utils.py
@@ -1,45 +1,6 @@
 import os
-from functools import lru_cache
-
-from erica.erica_legacy.elster_xml import elster_xml_generator
-from erica.erica_legacy.elster_xml.xml_parsing.erica_xml_parsing import remove_declaration_and_namespace
-from erica.erica_legacy.pyeric.pyeric_controller import PermitListingPyericProcessController
 
 _INSTANCES_FOLDER = os.path.join('erica', 'instances')
 _BLUEPRINT_FOLDER = os.path.join(_INSTANCES_FOLDER, 'blueprint')
 
-NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
 
-
-def reset_new_request_id_list():
-    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
-    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION = []
-
-
-def add_new_request_id_to_cache_list(request_id):
-    global NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION
-    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION.append(request_id)
-
-
-def get_vast_list_from_xml(xml):
-    simple_xml = remove_declaration_and_namespace(xml)
-    return {antrag.find('.//AntragsID').text: antrag.find('.//DateninhaberIdNr').text for antrag in simple_xml.findall('.//Antrag')}
-
-
-@lru_cache
-def get_list_vast_requests(pyeric_controller):
-    xml = elster_xml_generator.generate_full_vast_list_xml()
-    result = pyeric_controller(xml=xml).get_eric_response()
-    vast_request_list = get_vast_list_from_xml(result.server_response)
-    reset_new_request_id_list()
-    return vast_request_list
-
-
-def tax_id_number_is_test_id_number(tax_id_number):
-    return tax_id_number[0] == "0"
-
-
-def request_needs_testmerker(request_id):
-    if request_id in NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION:
-        get_list_vast_requests.cache_clear()
-    return tax_id_number_is_test_id_number(get_list_vast_requests(PermitListingPyericProcessController).get(request_id))

--- a/erica/erica_legacy/request_processing/requests_controller.py
+++ b/erica/erica_legacy/request_processing/requests_controller.py
@@ -18,20 +18,10 @@ from erica.erica_legacy.pyeric.pyeric_controller import EstPyericProcessControll
     UnlockCodeRevocationPyericProcessController, \
     DecryptBelegePyericController, BelegIdRequestPyericProcessController, \
     BelegRequestPyericProcessController, CheckTaxNumberPyericController
-from erica.erica_legacy.pyeric.check_elster_request_id import add_new_request_id_to_cache_list, request_needs_testmerker
+from erica.erica_legacy.pyeric.check_elster_request_id import add_new_request_id_to_cache_list, \
+    request_needs_testmerker, tax_id_number_is_test_id_number
 from erica.erica_legacy.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.erica_legacy.request_processing.erica_input.v1.erica_input import UnlockCodeRequestData, EstData
-
-SPECIAL_TESTMERKER_IDNR = ['04452397687',
-                           '02259674819',
-                           '04452317681',
-                           '09952417688',
-                           '03352417692',
-                           '03352419681',
-                           '03352417981',
-                           '03392417683',
-                           '03352917681',
-                           '03359417681']
 
 
 class EricaRequestController(object):
@@ -62,7 +52,7 @@ class EricaRequestController(object):
         raise NotImplementedError
 
     def _is_testmerker_used(self):
-        return self.input_data.tax_id_number in SPECIAL_TESTMERKER_IDNR
+        return tax_id_number_is_test_id_number(self.input_data.tax_id_number)
 
     def generate_json(self, pyeric_response: PyericResponse):
         response = {}
@@ -88,7 +78,7 @@ class EstValidationRequestController(TransferTicketRequestController):
         super().__init__(input_data, include_elster_responses)
 
     def _is_testmerker_used(self):
-        return self.input_data.est_data.person_a_idnr in SPECIAL_TESTMERKER_IDNR
+        return tax_id_number_is_test_id_number(self.input_data.est_data.person_a_idnr)
 
     def process(self):
         # Translate our form data structure into the fields from
@@ -166,7 +156,7 @@ class UnlockCodeActivationRequestController(TransferTicketRequestController):
 
     def _is_testmerker_used(self):
         if self.input_data.tax_id_number:
-            return self.input_data.tax_id_number in SPECIAL_TESTMERKER_IDNR
+            return tax_id_number_is_test_id_number(self.input_data.tax_id_number)
         else:
             return request_needs_testmerker(self.input_data.elster_request_id)
 
@@ -186,7 +176,7 @@ class UnlockCodeRevocationRequestController(TransferTicketRequestController):
 
     def _is_testmerker_used(self):
         if self.input_data.tax_id_number:
-            return self.input_data.tax_id_number in SPECIAL_TESTMERKER_IDNR
+            return tax_id_number_is_test_id_number(self.input_data.tax_id_number)
         else:
             return request_needs_testmerker(self.input_data.elster_request_id)
 

--- a/erica/erica_legacy/request_processing/requests_controller.py
+++ b/erica/erica_legacy/request_processing/requests_controller.py
@@ -18,7 +18,7 @@ from erica.erica_legacy.pyeric.pyeric_controller import EstPyericProcessControll
     UnlockCodeRevocationPyericProcessController, \
     DecryptBelegePyericController, BelegIdRequestPyericProcessController, \
     BelegRequestPyericProcessController, CheckTaxNumberPyericController
-from erica.erica_legacy.pyeric.utils import add_new_request_id_to_cache_list, request_needs_testmerker
+from erica.erica_legacy.pyeric.check_elster_request_id import add_new_request_id_to_cache_list, request_needs_testmerker
 from erica.erica_legacy.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.erica_legacy.request_processing.erica_input.v1.erica_input import UnlockCodeRequestData, EstData
 

--- a/tests/erica_legacy/pyeric/test_check_elster_request_id.py
+++ b/tests/erica_legacy/pyeric/test_check_elster_request_id.py
@@ -4,7 +4,8 @@ import pytest
 
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from erica.erica_legacy.pyeric.check_elster_request_id import get_vast_list_from_xml, get_list_vast_requests, \
-    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION, add_new_request_id_to_cache_list, request_needs_testmerker
+    NEW_REQUEST_ID_SINCE_LAST_CACHE_INVALIDATION, add_new_request_id_to_cache_list, request_needs_testmerker, \
+    reset_new_request_id_list
 from tests.erica_legacy.utils import missing_pyeric_lib
 from tests.utils import read_text_from_sample
 
@@ -91,6 +92,7 @@ class TestRequestNeedsTestmerker:
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
     def test_if_idnr_not_in_list_then_cache_not_invalidated(self):
         idnr = "1234"
+        reset_new_request_id_list()
         with patch('erica.erica_legacy.pyeric.check_elster_request_id.get_list_vast_requests') as get_list_vast_requests_mock:
 
             request_needs_testmerker(idnr)

--- a/tests/erica_legacy/pyeric/test_check_elster_request_id.py
+++ b/tests/erica_legacy/pyeric/test_check_elster_request_id.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
-from erica.erica_legacy.pyeric.utils import get_list_vast_requests, get_vast_list_from_xml
+from erica.erica_legacy.pyeric.check_elster_request_id import get_vast_list_from_xml, get_list_vast_requests
 from tests.erica_legacy.utils import missing_pyeric_lib
 from tests.utils import read_text_from_sample
 

--- a/tests/erica_legacy/pyeric/test_utils_.py
+++ b/tests/erica_legacy/pyeric/test_utils_.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
+from erica.erica_legacy.pyeric.utils import get_list_vast_requests, get_vast_list_from_xml
+from tests.erica_legacy.utils import missing_pyeric_lib
+from tests.utils import read_text_from_sample
+
+
+class TestGetVastListFromXml:
+
+    def test_if_entries_in_xml_then_return_correct_dict(self):
+        input_xml = read_text_from_sample('sample_vast_list.xml')
+        expected_dict = {
+            'br1652dntwz6wg1md87hc6055aij0nev': '02293417683',
+            'br1226cnpymxm35hf0ptmsmc2nqpv9y9': '03392417683',
+        }
+
+        actual_dict = get_vast_list_from_xml(input_xml)
+
+        assert actual_dict == expected_dict
+
+    def test_if_no_entries_in_xml_then_return_empty_dict(self):
+        input_xml = read_text_from_sample('sample_vast_list_empty.xml')
+        expected_dict = {}
+
+        actual_dict = get_vast_list_from_xml(input_xml)
+
+        assert actual_dict == expected_dict
+
+
+class MockPyericController(MagicMock):
+
+    @staticmethod
+    def get_eric_response():
+
+        return PyericResponse(eric_response="", server_response=read_text_from_sample('sample_vast_list.xml'))
+
+
+class TestListVastRequests:
+
+    @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
+    def test_if_cache_is_invalidated_then_call_pyeric_controller(self):
+        get_list_vast_requests.cache_clear()
+        mock_pyeric_controller = MockPyericController()
+
+        get_list_vast_requests(mock_pyeric_controller)
+
+        assert mock_pyeric_controller.call_count == 1
+
+    @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
+    def test_if_function_is_called_more_then_once_then_do_not_call_pyeric_controller_again(self):
+        get_list_vast_requests.cache_clear()
+        mock_pyeric_controller = MockPyericController()
+
+        get_list_vast_requests(mock_pyeric_controller)
+        get_list_vast_requests(mock_pyeric_controller)
+        get_list_vast_requests(mock_pyeric_controller)
+
+        assert mock_pyeric_controller.call_count == 1
+
+    @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
+    def test_if_function_is_called_more_then_once_and_cache_invalid_then_call_pyeric_controller_again(self):
+        get_list_vast_requests.cache_clear()
+        mock_pyeric_controller = MockPyericController()
+
+        get_list_vast_requests(mock_pyeric_controller)
+        get_list_vast_requests(mock_pyeric_controller)
+
+        get_list_vast_requests.cache_clear()
+
+        get_list_vast_requests(mock_pyeric_controller)
+
+        assert mock_pyeric_controller.call_count == 2

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock, call
 
 import pytest
 
+from erica.domain.FreischaltCode.FreischaltCode import FreischaltCodeActivatePayload, FreischaltCodeRevocatePayload
 from erica.domain.tax_number_validation.check_tax_number import CheckTaxNumberPayload
 from erica.erica_legacy.pyeric.eric_errors import InvalidBufaNumberError
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
@@ -329,6 +330,14 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
 
             self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
+    def test_if_not_special_idnr_then_create_xml_is_called_with_use_testmerker_set_false(self):
+        elster_request_id = "1234"
+        with patch('erica.erica_legacy.request_processing.requests_controller.TransferTicketRequestController.process', MagicMock(return_value={'elster_request_id': elster_request_id})),\
+            patch('erica.erica_legacy.request_processing.requests_controller.add_new_request_id_to_cache_list') as add_to_cache:
+            self.unlock_request_with_valid_input.process()
+
+            add_to_cache.assert_called_once_with(elster_request_id)
+
 
 class TestUnlockCodeRequestGenerateFullXml(unittest.TestCase):
 
@@ -441,6 +450,10 @@ class TestUnlockCodeActivationProcess(unittest.TestCase):
             unlock_code='1985-T67D-K89O',
             elster_request_id='42'))
 
+        self.unlock_activation_without_idnr = UnlockCodeActivationRequestController(FreischaltCodeActivatePayload(
+            freischalt_code='1985-T67D-K89O',
+            elster_request_id='42'))
+
     def test_pyeric_controller_is_initialised_with_correct_argument(self):
         xml = '<xml></xml>'
 
@@ -492,6 +505,32 @@ class TestUnlockCodeActivationProcess(unittest.TestCase):
                 patch(
                     'erica.erica_legacy.request_processing.requests_controller.UnlockCodeActivationRequestController.generate_json'):
             self.unlock_activation_with_valid_input.process()
+
+            self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
+
+    def test_if_idnr_and_request_needs_test_merker_then_create_xml_is_called_with_true(self):
+        with patch(
+                'erica.erica_legacy.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
+                patch(
+                    'erica.erica_legacy.pyeric.pyeric_controller.UnlockCodeActivationPyericProcessController.get_eric_response'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.UnlockCodeActivationRequestController.generate_json'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.request_needs_testmerker', MagicMock(return_value=True)):
+            self.unlock_activation_without_idnr.process()
+
+            self.assertTrue(generate_xml_fun.call_args.kwargs['use_testmerker'])
+
+    def test_if_idnr_and_request_needs_test_merker_then_create_xml_is_called_with_false(self):
+        with patch(
+                'erica.erica_legacy.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
+                patch(
+                    'erica.erica_legacy.pyeric.pyeric_controller.UnlockCodeActivationPyericProcessController.get_eric_response'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.UnlockCodeActivationRequestController.generate_json'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.request_needs_testmerker', MagicMock(return_value=False)):
+            self.unlock_activation_without_idnr.process()
 
             self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
@@ -578,6 +617,9 @@ class TestUnlockCodeRevocationProcess(unittest.TestCase):
             idnr="123456789",
             elster_request_id='lookyetanotherrequestid'))
 
+        self.unlock_revocation_without_idnr = UnlockCodeRevocationRequestController(FreischaltCodeRevocatePayload(
+            elster_request_id='lookyetanotherrequestid'))
+
     def test_pyeric_controller_is_initialised_with_correct_arguments(self):
         xml = '<xml></xml>'
 
@@ -629,6 +671,32 @@ class TestUnlockCodeRevocationProcess(unittest.TestCase):
                 patch(
                     'erica.erica_legacy.request_processing.requests_controller.UnlockCodeRevocationRequestController.generate_json'):
             self.unlock_revocation_with_valid_input.process()
+
+            self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
+
+    def test_if_idnr_and_request_needs_test_merker_then_create_xml_is_called_with_true(self):
+        with patch(
+                'erica.erica_legacy.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
+                patch(
+                    'erica.erica_legacy.pyeric.pyeric_controller.UnlockCodeRevocationPyericProcessController.get_eric_response'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.UnlockCodeRevocationRequestController.generate_json'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.request_needs_testmerker', MagicMock(return_value=True)):
+            self.unlock_revocation_without_idnr.process()
+
+            self.assertTrue(generate_xml_fun.call_args.kwargs['use_testmerker'])
+
+    def test_if_idnr_and_request_needs_test_merker_then_create_xml_is_called_with_false(self):
+        with patch(
+                'erica.erica_legacy.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
+                patch(
+                    'erica.erica_legacy.pyeric.pyeric_controller.UnlockCodeRevocationPyericProcessController.get_eric_response'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.UnlockCodeRevocationRequestController.generate_json'), \
+                patch(
+                    'erica.erica_legacy.request_processing.requests_controller.request_needs_testmerker', MagicMock(return_value=False)):
+            self.unlock_revocation_without_idnr.process()
 
             self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
 

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -7,6 +7,7 @@ import pytest
 
 from erica.domain.FreischaltCode.FreischaltCode import FreischaltCodeActivatePayload, FreischaltCodeRevocatePayload
 from erica.domain.tax_number_validation.check_tax_number import CheckTaxNumberPayload
+from erica.erica_legacy.pyeric.check_elster_request_id import SPECIAL_TESTMERKER_IDNR
 from erica.erica_legacy.pyeric.eric_errors import InvalidBufaNumberError
 from erica.erica_legacy.pyeric.pyeric_response import PyericResponse
 from erica.erica_legacy.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
@@ -15,7 +16,7 @@ from erica.erica_legacy.request_processing.erica_input.v1.erica_input import Unl
     UnlockCodeRevocationData, GetAddressData
 from erica.erica_legacy.request_processing.requests_controller import UnlockCodeRequestController, \
     UnlockCodeActivationRequestController, EstRequestController, EstValidationRequestController, \
-    UnlockCodeRevocationRequestController, SPECIAL_TESTMERKER_IDNR, GetAddressRequestController, \
+    UnlockCodeRevocationRequestController, GetAddressRequestController, \
     GetBelegeRequestController, CheckTaxNumberRequestController
 from tests.erica_legacy.utils import create_est, missing_cert, missing_pyeric_lib, replace_text_in_xml, \
     replace_subtree_in_xml, TEST_EST_VERANLAGUNGSJAHR

--- a/tests/erica_legacy/request_processing/test_requests_controller.py
+++ b/tests/erica_legacy/request_processing/test_requests_controller.py
@@ -331,13 +331,13 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
 
             self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
-    def test_if_not_special_idnr_then_create_xml_is_called_with_use_testmerker_set_false(self):
+    def test_if_processed_called_then_elster_request_id_added_to_cache_list(self):
         elster_request_id = "1234"
         with patch('erica.erica_legacy.request_processing.requests_controller.TransferTicketRequestController.process', MagicMock(return_value={'elster_request_id': elster_request_id})),\
-            patch('erica.erica_legacy.request_processing.requests_controller.add_new_request_id_to_cache_list') as add_to_cache:
+            patch('erica.erica_legacy.request_processing.requests_controller.add_new_request_id_to_cache_list') as add_to_cache_list:
             self.unlock_request_with_valid_input.process()
 
-            add_to_cache.assert_called_once_with(elster_request_id)
+            add_to_cache_list.assert_called_once_with(elster_request_id)
 
 
 class TestUnlockCodeRequestGenerateFullXml(unittest.TestCase):

--- a/tests/erica_legacy/samples/sample_vast_list.xml
+++ b/tests/erica_legacy/samples/sample_vast_list.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?><Elster xmlns="http://www.elster.de/elsterxml/schema/v11"><TransferHeader version="11"><Verfahren>ElsterBRM</Verfahren><DatenArt>SpezRechtListe</DatenArt><Vorgang>send-Auth</Vorgang><TransferTicket>et1263dz1n176m23i28wo7y26p7m2u1x</TransferTicket><Testmerker>370000001</Testmerker><Empfaenger id="L"><Ziel>CS</Ziel></Empfaenger><HerstellerID>74931</HerstellerID><DatenLieferant>MIAGCSqGSIb3DQEHBqCAMIACAQAwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAiNEOINi7rvPaCA
+BDAEhZHcXImlDlDWiSGihmk+m1RvMbUN6tkfvnzSz3U6oMmtR96q7+NhfGMzpuF81vIAAAAAAAAA
+AAAA
+</DatenLieferant><EingangsDatum>20220506171819</EingangsDatum><Datei><Verschluesselung>CMSEncryptedData</Verschluesselung><Kompression>GZIP</Kompression><TransportSchluessel>MIAGCSqGSIb3DQEHBqCAMIACAQAwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAj2hxfc5o8SlKCA
+BBhr0p8Eo6fp8VJnEWicewlnzeXIZV0U/XUAAAAAAAAAAAAA
+</TransportSchluessel></Datei><RC><Rueckgabe><Code>0</Code><Text>OK</Text></Rueckgabe><Stack><Code>0</Code><Text></Text></Stack></RC><VersionClient>1</VersionClient><Zusatz><Info>CorrelationID:d2b78f29-ccb1-4a21-a905-a40ad49429e7</Info></Zusatz></TransferHeader><DatenTeil><Nutzdatenblock><NutzdatenHeader version="11"><NutzdatenTicket>1</NutzdatenTicket><Empfaenger id="L">CS</Empfaenger><RC><Rueckgabe><Code>0</Code><Text>OK</Text></Rueckgabe><Stack><Code>0</Code><Text></Text></Stack></RC></NutzdatenHeader><Nutzdaten>
+                <SpezRechtListe version="7">
+                    <Antrag xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="DatenabruferAntragCType">
+                        <AntragsID>br1652dntwz6wg1md87hc6055aij0nev</AntragsID>
+                        <AntragsDatum>2021-06-14T15:43:54.238+02:00</AntragsDatum>
+                        <GueltigBis>2224-12-31</GueltigBis>
+                        <AntragsStatus>genehmigt</AntragsStatus>
+                        <Recht>AbrufEBelege</Recht>
+                        <Veranlagungszeitraum>
+                            <Unbeschraenkt>true</Unbeschraenkt>
+                        </Veranlagungszeitraum>
+                        <DateninhaberIdNr>02293417683</DateninhaberIdNr>
+                    </Antrag>
+                    <Antrag xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="DatenabruferAntragCType">
+                        <AntragsID>br1226cnpymxm35hf0ptmsmc2nqpv9y9</AntragsID>
+                        <AntragsDatum>2022-05-02T14:02:48.564+02:00</AntragsDatum>
+                        <GueltigBis>2022-12-31</GueltigBis>
+                        <AntragsStatus>genehmigt</AntragsStatus>
+                        <Recht>AbrufEBelege</Recht>
+                        <Veranlagungszeitraum>
+                            <Unbeschraenkt>false</Unbeschraenkt>
+                            <Veranlagungsjahre>
+                                <Jahr>2021</Jahr>
+                            </Veranlagungsjahre>
+                        </Veranlagungszeitraum>
+                        <DateninhaberIdNr>03392417683</DateninhaberIdNr>
+                    </Antrag>
+                </SpezRechtListe>
+            </Nutzdaten></Nutzdatenblock></DatenTeil></Elster>

--- a/tests/erica_legacy/samples/sample_vast_list_empty.xml
+++ b/tests/erica_legacy/samples/sample_vast_list_empty.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><Elster xmlns="http://www.elster.de/elsterxml/schema/v11"><TransferHeader version="11"><Verfahren>ElsterBRM</Verfahren><DatenArt>SpezRechtListe</DatenArt><Vorgang>send-Auth</Vorgang><TransferTicket>et1263dz1n176m23i28wo7y26p7m2u1x</TransferTicket><Testmerker>370000001</Testmerker><Empfaenger id="L"><Ziel>CS</Ziel></Empfaenger><HerstellerID>74931</HerstellerID><DatenLieferant>MIAGCSqGSIb3DQEHBqCAMIACAQAwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAiNEOINi7rvPaCA
+BDAEhZHcXImlDlDWiSGihmk+m1RvMbUN6tkfvnzSz3U6oMmtR96q7+NhfGMzpuF81vIAAAAAAAAA
+AAAA
+</DatenLieferant><EingangsDatum>20220506171819</EingangsDatum><Datei><Verschluesselung>CMSEncryptedData</Verschluesselung><Kompression>GZIP</Kompression><TransportSchluessel>MIAGCSqGSIb3DQEHBqCAMIACAQAwgAYJKoZIhvcNAQcBMBQGCCqGSIb3DQMHBAj2hxfc5o8SlKCA
+BBhr0p8Eo6fp8VJnEWicewlnzeXIZV0U/XUAAAAAAAAAAAAA
+</TransportSchluessel></Datei><RC><Rueckgabe><Code>0</Code><Text>OK</Text></Rueckgabe><Stack><Code>0</Code><Text></Text></Stack></RC><VersionClient>1</VersionClient><Zusatz><Info>CorrelationID:d2b78f29-ccb1-4a21-a905-a40ad49429e7</Info></Zusatz></TransferHeader><DatenTeil><Nutzdatenblock><NutzdatenHeader version="11"><NutzdatenTicket>1</NutzdatenTicket><Empfaenger id="L">CS</Empfaenger><RC><Rueckgabe><Code>0</Code><Text>OK</Text></Rueckgabe><Stack><Code>0</Code><Text></Text></Stack></RC></NutzdatenHeader><Nutzdaten>
+            </Nutzdaten></Nutzdatenblock></DatenTeil></Elster>


### PR DESCRIPTION
# Short Description
We do not need the id number to send an FSC request to erica. However, we do need it to make decide whether the testidnumber should be set. This allows us to check whether the testidnumber needs to be set by looking for the corresponding id number of an elster request.

# Changes
- Add some utils functions to check whether a test merker is required
- Change how is_testmerker_used works for fsc activation and revocation

# Feedback
- Do you see any problem with this approach?
- Do you see any tests that might be useful (e.g. on an integration level or as contract tests)?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
